### PR TITLE
Remove omitempty tag from IsFlaky

### DIFF
--- a/client/model_test_case_create.go
+++ b/client/model_test_case_create.go
@@ -10,7 +10,7 @@ type TestCaseCreate struct {
 	Behavior       int32                 `json:"behavior,omitempty"`
 	Type_          int32                 `json:"type,omitempty"`
 	Layer          int32                 `json:"layer,omitempty"`
-	IsFlaky        int32                 `json:"is_flaky,omitempty"`
+	IsFlaky        int32                 `json:"is_flaky"`
 	SuiteId        int64                 `json:"suite_id,omitempty"`
 	MilestoneId    int64                 `json:"milestone_id,omitempty"`
 	Automation     int32                 `json:"automation,omitempty"`


### PR DESCRIPTION
`IsFlaky` is a required field for the API. Due to the fact that it is has an `omitempty` tag, a zero is interpreted by the json parser as not being set while zero is a valid entry. Therefore when attempting to set `IsFlaky` to zero I get an 422 status error, since IsFlaky is not set.