### PR TITLE
Added custom fields to RunCreate

### DIFF
--- a/client/model_run_create.go
+++ b/client/model_run_create.go
@@ -10,4 +10,6 @@ type RunCreate struct {
 	MilestoneId     int64    `json:"milestone_id,omitempty"`
 	PlanId          int64    `json:"plan_id,omitempty"`
 	Tags            []string `json:"tags,omitempty"`
+	// A map of custom fields values (id => value)
+	CustomField map[string]string `json:"custom_field,omitempty"`
 }


### PR DESCRIPTION
The RunCreate struct is missing the CustomFields map that the API supports now. Added the new field to the struct.