### PR TITLE
chore: regenerate API clients based on the latest specification

### DIFF
--- a/qase-api-client/api_cases.go
+++ b/qase-api-client/api_cases.go
@@ -692,6 +692,13 @@ type ApiGetCaseRequest struct {
 	ApiService *CasesAPIService
 	code       string
 	id         int32
+	include    *string
+}
+
+// A list of entities to include in response separated by comma. Possible values: external_issues.
+func (r ApiGetCaseRequest) Include(include string) ApiGetCaseRequest {
+	r.include = &include
+	return r
 }
 
 func (r ApiGetCaseRequest) Execute() (*TestCaseResponse, *http.Response, error) {
@@ -747,6 +754,9 @@ func (a *CasesAPIService) GetCaseExecute(r ApiGetCaseRequest) (*TestCaseResponse
 		return localVarReturnValue, nil, reportError("code must have less than 10 elements")
 	}
 
+	if r.include != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "include", r.include, "")
+	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 

--- a/qase-api-client/docs/CasesAPI.md
+++ b/qase-api-client/docs/CasesAPI.md
@@ -374,7 +374,7 @@ Name | Type | Description  | Notes
 
 ## GetCase
 
-> TestCaseResponse GetCase(ctx, code, id).Execute()
+> TestCaseResponse GetCase(ctx, code, id).Include(include).Execute()
 
 Get a specific test case
 
@@ -395,10 +395,11 @@ import (
 func main() {
 	code := "code_example" // string | Code of project, where to search entities.
 	id := int32(56) // int32 | Identifier.
+	include := "include_example" // string | A list of entities to include in response separated by comma. Possible values: external_issues.  (optional)
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)
-	resp, r, err := apiClient.CasesAPI.GetCase(context.Background(), code, id).Execute()
+	resp, r, err := apiClient.CasesAPI.GetCase(context.Background(), code, id).Include(include).Execute()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error when calling `CasesAPI.GetCase``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -426,6 +427,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
 
+ **include** | **string** | A list of entities to include in response separated by comma. Possible values: external_issues.  | 
 
 ### Return type
 

--- a/qase-api-client/docs/QqlTestCase.md
+++ b/qase-api-client/docs/QqlTestCase.md
@@ -31,6 +31,7 @@ Name | Type | Description | Notes
 **AuthorId** | Pointer to **int64** |  | [optional] 
 **CreatedAt** | Pointer to **time.Time** |  | [optional] 
 **UpdatedAt** | Pointer to **time.Time** |  | [optional] 
+**UpdatedBy** | Pointer to **int64** | Author ID of the last update. | [optional] 
 
 ## Methods
 
@@ -780,6 +781,31 @@ SetUpdatedAt sets UpdatedAt field to given value.
 `func (o *QqlTestCase) HasUpdatedAt() bool`
 
 HasUpdatedAt returns a boolean if a field has been set.
+
+### GetUpdatedBy
+
+`func (o *QqlTestCase) GetUpdatedBy() int64`
+
+GetUpdatedBy returns the UpdatedBy field if non-nil, zero value otherwise.
+
+### GetUpdatedByOk
+
+`func (o *QqlTestCase) GetUpdatedByOk() (*int64, bool)`
+
+GetUpdatedByOk returns a tuple with the UpdatedBy field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetUpdatedBy
+
+`func (o *QqlTestCase) SetUpdatedBy(v int64)`
+
+SetUpdatedBy sets UpdatedBy field to given value.
+
+### HasUpdatedBy
+
+`func (o *QqlTestCase) HasUpdatedBy() bool`
+
+HasUpdatedBy returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/qase-api-client/docs/Run.md
+++ b/qase-api-client/docs/Run.md
@@ -15,6 +15,7 @@ Name | Type | Description | Notes
 **Public** | Pointer to **bool** |  | [optional] 
 **Stats** | Pointer to [**RunStats**](RunStats.md) |  | [optional] 
 **TimeSpent** | Pointer to **int64** | Time in ms. | [optional] 
+**ElapsedTime** | Pointer to **int64** | Time in ms. | [optional] 
 **Environment** | Pointer to [**NullableRunEnvironment**](RunEnvironment.md) |  | [optional] 
 **Milestone** | Pointer to [**NullableRunMilestone**](RunMilestone.md) |  | [optional] 
 **CustomFields** | Pointer to [**[]CustomFieldValue**](CustomFieldValue.md) |  | [optional] 
@@ -345,6 +346,31 @@ SetTimeSpent sets TimeSpent field to given value.
 `func (o *Run) HasTimeSpent() bool`
 
 HasTimeSpent returns a boolean if a field has been set.
+
+### GetElapsedTime
+
+`func (o *Run) GetElapsedTime() int64`
+
+GetElapsedTime returns the ElapsedTime field if non-nil, zero value otherwise.
+
+### GetElapsedTimeOk
+
+`func (o *Run) GetElapsedTimeOk() (*int64, bool)`
+
+GetElapsedTimeOk returns a tuple with the ElapsedTime field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetElapsedTime
+
+`func (o *Run) SetElapsedTime(v int64)`
+
+SetElapsedTime sets ElapsedTime field to given value.
+
+### HasElapsedTime
+
+`func (o *Run) HasElapsedTime() bool`
+
+HasElapsedTime returns a boolean if a field has been set.
 
 ### GetEnvironment
 

--- a/qase-api-client/docs/RunQuery.md
+++ b/qase-api-client/docs/RunQuery.md
@@ -15,6 +15,7 @@ Name | Type | Description | Notes
 **Public** | Pointer to **bool** |  | [optional] 
 **Stats** | Pointer to [**RunStats**](RunStats.md) |  | [optional] 
 **TimeSpent** | Pointer to **int64** | Time in ms. | [optional] 
+**ElapsedTime** | Pointer to **int64** | Time in ms. | [optional] 
 **Environment** | Pointer to [**NullableRunEnvironment**](RunEnvironment.md) |  | [optional] 
 **Milestone** | Pointer to [**NullableRunMilestone**](RunMilestone.md) |  | [optional] 
 **CustomFields** | Pointer to [**[]CustomFieldValue**](CustomFieldValue.md) |  | [optional] 
@@ -340,6 +341,31 @@ SetTimeSpent sets TimeSpent field to given value.
 `func (o *RunQuery) HasTimeSpent() bool`
 
 HasTimeSpent returns a boolean if a field has been set.
+
+### GetElapsedTime
+
+`func (o *RunQuery) GetElapsedTime() int64`
+
+GetElapsedTime returns the ElapsedTime field if non-nil, zero value otherwise.
+
+### GetElapsedTimeOk
+
+`func (o *RunQuery) GetElapsedTimeOk() (*int64, bool)`
+
+GetElapsedTimeOk returns a tuple with the ElapsedTime field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetElapsedTime
+
+`func (o *RunQuery) SetElapsedTime(v int64)`
+
+SetElapsedTime sets ElapsedTime field to given value.
+
+### HasElapsedTime
+
+`func (o *RunQuery) HasElapsedTime() bool`
+
+HasElapsedTime returns a boolean if a field has been set.
 
 ### GetEnvironment
 

--- a/qase-api-client/docs/SearchResponseAllOfResultEntities.md
+++ b/qase-api-client/docs/SearchResponseAllOfResultEntities.md
@@ -15,6 +15,7 @@ Name | Type | Description | Notes
 **Public** | Pointer to **bool** |  | [optional] 
 **Stats** | Pointer to [**RunStats**](RunStats.md) |  | [optional] 
 **TimeSpent** | Pointer to **int64** | Time in ms. | [optional] 
+**ElapsedTime** | Pointer to **int64** | Time in ms. | [optional] 
 **Environment** | Pointer to [**NullableRunEnvironment**](RunEnvironment.md) |  | [optional] 
 **Milestone** | Pointer to [**NullableRunMilestone**](RunMilestone.md) |  | [optional] 
 **CustomFields** | Pointer to [**[]CustomFieldValue**](CustomFieldValue.md) |  | [optional] 
@@ -51,6 +52,7 @@ Name | Type | Description | Notes
 **StepsType** | Pointer to **NullableString** |  | [optional] 
 **Params** | Pointer to [**TestCaseParams**](TestCaseParams.md) |  | [optional] 
 **AuthorId** | Pointer to **int64** |  | [optional] 
+**UpdatedBy** | Pointer to **int64** | Author ID of the last update. | [optional] 
 **DefectId** | **int64** |  | 
 **ActualResult** | Pointer to **string** |  | [optional] 
 **Resolved** | Pointer to **NullableTime** |  | [optional] 
@@ -375,6 +377,31 @@ SetTimeSpent sets TimeSpent field to given value.
 `func (o *SearchResponseAllOfResultEntities) HasTimeSpent() bool`
 
 HasTimeSpent returns a boolean if a field has been set.
+
+### GetElapsedTime
+
+`func (o *SearchResponseAllOfResultEntities) GetElapsedTime() int64`
+
+GetElapsedTime returns the ElapsedTime field if non-nil, zero value otherwise.
+
+### GetElapsedTimeOk
+
+`func (o *SearchResponseAllOfResultEntities) GetElapsedTimeOk() (*int64, bool)`
+
+GetElapsedTimeOk returns a tuple with the ElapsedTime field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetElapsedTime
+
+`func (o *SearchResponseAllOfResultEntities) SetElapsedTime(v int64)`
+
+SetElapsedTime sets ElapsedTime field to given value.
+
+### HasElapsedTime
+
+`func (o *SearchResponseAllOfResultEntities) HasElapsedTime() bool`
+
+HasElapsedTime returns a boolean if a field has been set.
 
 ### GetEnvironment
 
@@ -1355,6 +1382,31 @@ SetAuthorId sets AuthorId field to given value.
 `func (o *SearchResponseAllOfResultEntities) HasAuthorId() bool`
 
 HasAuthorId returns a boolean if a field has been set.
+
+### GetUpdatedBy
+
+`func (o *SearchResponseAllOfResultEntities) GetUpdatedBy() int64`
+
+GetUpdatedBy returns the UpdatedBy field if non-nil, zero value otherwise.
+
+### GetUpdatedByOk
+
+`func (o *SearchResponseAllOfResultEntities) GetUpdatedByOk() (*int64, bool)`
+
+GetUpdatedByOk returns a tuple with the UpdatedBy field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetUpdatedBy
+
+`func (o *SearchResponseAllOfResultEntities) SetUpdatedBy(v int64)`
+
+SetUpdatedBy sets UpdatedBy field to given value.
+
+### HasUpdatedBy
+
+`func (o *SearchResponseAllOfResultEntities) HasUpdatedBy() bool`
+
+HasUpdatedBy returns a boolean if a field has been set.
 
 ### GetDefectId
 

--- a/qase-api-client/docs/TestCaseQuery.md
+++ b/qase-api-client/docs/TestCaseQuery.md
@@ -31,6 +31,7 @@ Name | Type | Description | Notes
 **AuthorId** | Pointer to **int64** |  | [optional] 
 **CreatedAt** | Pointer to **time.Time** |  | [optional] 
 **UpdatedAt** | Pointer to **time.Time** |  | [optional] 
+**UpdatedBy** | Pointer to **int64** | Author ID of the last update. | [optional] 
 
 ## Methods
 
@@ -780,6 +781,31 @@ SetUpdatedAt sets UpdatedAt field to given value.
 `func (o *TestCaseQuery) HasUpdatedAt() bool`
 
 HasUpdatedAt returns a boolean if a field has been set.
+
+### GetUpdatedBy
+
+`func (o *TestCaseQuery) GetUpdatedBy() int64`
+
+GetUpdatedBy returns the UpdatedBy field if non-nil, zero value otherwise.
+
+### GetUpdatedByOk
+
+`func (o *TestCaseQuery) GetUpdatedByOk() (*int64, bool)`
+
+GetUpdatedByOk returns a tuple with the UpdatedBy field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetUpdatedBy
+
+`func (o *TestCaseQuery) SetUpdatedBy(v int64)`
+
+SetUpdatedBy sets UpdatedBy field to given value.
+
+### HasUpdatedBy
+
+`func (o *TestCaseQuery) HasUpdatedBy() bool`
+
+HasUpdatedBy returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/qase-api-client/model_qql_test_case.go
+++ b/qase-api-client/model_qql_test_case.go
@@ -52,6 +52,8 @@ type QqlTestCase struct {
 	AuthorId  *int64     `json:"author_id,omitempty"`
 	CreatedAt *time.Time `json:"created_at,omitempty"`
 	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+	// Author ID of the last update.
+	UpdatedBy *int64 `json:"updated_by,omitempty"`
 }
 
 type _QqlTestCase QqlTestCase
@@ -999,6 +1001,38 @@ func (o *QqlTestCase) SetUpdatedAt(v time.Time) {
 	o.UpdatedAt = &v
 }
 
+// GetUpdatedBy returns the UpdatedBy field value if set, zero value otherwise.
+func (o *QqlTestCase) GetUpdatedBy() int64 {
+	if o == nil || IsNil(o.UpdatedBy) {
+		var ret int64
+		return ret
+	}
+	return *o.UpdatedBy
+}
+
+// GetUpdatedByOk returns a tuple with the UpdatedBy field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *QqlTestCase) GetUpdatedByOk() (*int64, bool) {
+	if o == nil || IsNil(o.UpdatedBy) {
+		return nil, false
+	}
+	return o.UpdatedBy, true
+}
+
+// HasUpdatedBy returns a boolean if a field has been set.
+func (o *QqlTestCase) HasUpdatedBy() bool {
+	if o != nil && !IsNil(o.UpdatedBy) {
+		return true
+	}
+
+	return false
+}
+
+// SetUpdatedBy gets a reference to the given int64 and assigns it to the UpdatedBy field.
+func (o *QqlTestCase) SetUpdatedBy(v int64) {
+	o.UpdatedBy = &v
+}
+
 func (o QqlTestCase) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -1087,6 +1121,9 @@ func (o QqlTestCase) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.UpdatedAt) {
 		toSerialize["updated_at"] = o.UpdatedAt
+	}
+	if !IsNil(o.UpdatedBy) {
+		toSerialize["updated_by"] = o.UpdatedBy
 	}
 	return toSerialize, nil
 }

--- a/qase-api-client/model_run.go
+++ b/qase-api-client/model_run.go
@@ -32,7 +32,9 @@ type Run struct {
 	Public      *bool          `json:"public,omitempty"`
 	Stats       *RunStats      `json:"stats,omitempty"`
 	// Time in ms.
-	TimeSpent    *int64                 `json:"time_spent,omitempty"`
+	TimeSpent *int64 `json:"time_spent,omitempty"`
+	// Time in ms.
+	ElapsedTime  *int64                 `json:"elapsed_time,omitempty"`
 	Environment  NullableRunEnvironment `json:"environment,omitempty"`
 	Milestone    NullableRunMilestone   `json:"milestone,omitempty"`
 	CustomFields []CustomFieldValue     `json:"custom_fields,omitempty"`
@@ -443,6 +445,38 @@ func (o *Run) SetTimeSpent(v int64) {
 	o.TimeSpent = &v
 }
 
+// GetElapsedTime returns the ElapsedTime field value if set, zero value otherwise.
+func (o *Run) GetElapsedTime() int64 {
+	if o == nil || IsNil(o.ElapsedTime) {
+		var ret int64
+		return ret
+	}
+	return *o.ElapsedTime
+}
+
+// GetElapsedTimeOk returns a tuple with the ElapsedTime field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Run) GetElapsedTimeOk() (*int64, bool) {
+	if o == nil || IsNil(o.ElapsedTime) {
+		return nil, false
+	}
+	return o.ElapsedTime, true
+}
+
+// HasElapsedTime returns a boolean if a field has been set.
+func (o *Run) HasElapsedTime() bool {
+	if o != nil && !IsNil(o.ElapsedTime) {
+		return true
+	}
+
+	return false
+}
+
+// SetElapsedTime gets a reference to the given int64 and assigns it to the ElapsedTime field.
+func (o *Run) SetElapsedTime(v int64) {
+	o.ElapsedTime = &v
+}
+
 // GetEnvironment returns the Environment field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *Run) GetEnvironment() RunEnvironment {
 	if o == nil || IsNil(o.Environment.Get()) {
@@ -710,6 +744,9 @@ func (o Run) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.TimeSpent) {
 		toSerialize["time_spent"] = o.TimeSpent
+	}
+	if !IsNil(o.ElapsedTime) {
+		toSerialize["elapsed_time"] = o.ElapsedTime
 	}
 	if o.Environment.IsSet() {
 		toSerialize["environment"] = o.Environment.Get()

--- a/qase-api-client/model_run_query.go
+++ b/qase-api-client/model_run_query.go
@@ -34,7 +34,9 @@ type RunQuery struct {
 	Public      *bool          `json:"public,omitempty"`
 	Stats       *RunStats      `json:"stats,omitempty"`
 	// Time in ms.
-	TimeSpent    *int64                 `json:"time_spent,omitempty"`
+	TimeSpent *int64 `json:"time_spent,omitempty"`
+	// Time in ms.
+	ElapsedTime  *int64                 `json:"elapsed_time,omitempty"`
 	Environment  NullableRunEnvironment `json:"environment,omitempty"`
 	Milestone    NullableRunMilestone   `json:"milestone,omitempty"`
 	CustomFields []CustomFieldValue     `json:"custom_fields,omitempty"`
@@ -440,6 +442,38 @@ func (o *RunQuery) SetTimeSpent(v int64) {
 	o.TimeSpent = &v
 }
 
+// GetElapsedTime returns the ElapsedTime field value if set, zero value otherwise.
+func (o *RunQuery) GetElapsedTime() int64 {
+	if o == nil || IsNil(o.ElapsedTime) {
+		var ret int64
+		return ret
+	}
+	return *o.ElapsedTime
+}
+
+// GetElapsedTimeOk returns a tuple with the ElapsedTime field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *RunQuery) GetElapsedTimeOk() (*int64, bool) {
+	if o == nil || IsNil(o.ElapsedTime) {
+		return nil, false
+	}
+	return o.ElapsedTime, true
+}
+
+// HasElapsedTime returns a boolean if a field has been set.
+func (o *RunQuery) HasElapsedTime() bool {
+	if o != nil && !IsNil(o.ElapsedTime) {
+		return true
+	}
+
+	return false
+}
+
+// SetElapsedTime gets a reference to the given int64 and assigns it to the ElapsedTime field.
+func (o *RunQuery) SetElapsedTime(v int64) {
+	o.ElapsedTime = &v
+}
+
 // GetEnvironment returns the Environment field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *RunQuery) GetEnvironment() RunEnvironment {
 	if o == nil || IsNil(o.Environment.Get()) {
@@ -705,6 +739,9 @@ func (o RunQuery) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.TimeSpent) {
 		toSerialize["time_spent"] = o.TimeSpent
+	}
+	if !IsNil(o.ElapsedTime) {
+		toSerialize["elapsed_time"] = o.ElapsedTime
 	}
 	if o.Environment.IsSet() {
 		toSerialize["environment"] = o.Environment.Get()

--- a/qase-api-client/model_test_case_query.go
+++ b/qase-api-client/model_test_case_query.go
@@ -52,6 +52,8 @@ type TestCaseQuery struct {
 	AuthorId  *int64     `json:"author_id,omitempty"`
 	CreatedAt *time.Time `json:"created_at,omitempty"`
 	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+	// Author ID of the last update.
+	UpdatedBy *int64 `json:"updated_by,omitempty"`
 }
 
 type _TestCaseQuery TestCaseQuery
@@ -999,6 +1001,38 @@ func (o *TestCaseQuery) SetUpdatedAt(v time.Time) {
 	o.UpdatedAt = &v
 }
 
+// GetUpdatedBy returns the UpdatedBy field value if set, zero value otherwise.
+func (o *TestCaseQuery) GetUpdatedBy() int64 {
+	if o == nil || IsNil(o.UpdatedBy) {
+		var ret int64
+		return ret
+	}
+	return *o.UpdatedBy
+}
+
+// GetUpdatedByOk returns a tuple with the UpdatedBy field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TestCaseQuery) GetUpdatedByOk() (*int64, bool) {
+	if o == nil || IsNil(o.UpdatedBy) {
+		return nil, false
+	}
+	return o.UpdatedBy, true
+}
+
+// HasUpdatedBy returns a boolean if a field has been set.
+func (o *TestCaseQuery) HasUpdatedBy() bool {
+	if o != nil && !IsNil(o.UpdatedBy) {
+		return true
+	}
+
+	return false
+}
+
+// SetUpdatedBy gets a reference to the given int64 and assigns it to the UpdatedBy field.
+func (o *TestCaseQuery) SetUpdatedBy(v int64) {
+	o.UpdatedBy = &v
+}
+
 func (o TestCaseQuery) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -1087,6 +1121,9 @@ func (o TestCaseQuery) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.UpdatedAt) {
 		toSerialize["updated_at"] = o.UpdatedAt
+	}
+	if !IsNil(o.UpdatedBy) {
+		toSerialize["updated_by"] = o.UpdatedBy
 	}
 	return toSerialize, nil
 }

--- a/qase-api-v2-client/docs/ResultCreate.md
+++ b/qase-api-v2-client/docs/ResultCreate.md
@@ -7,7 +7,8 @@ Name | Type | Description | Notes
 **Id** | Pointer to **string** | If passed, used as an idempotency key | [optional] 
 **Title** | **string** |  | 
 **Signature** | Pointer to **string** |  | [optional] 
-**TestopsId** | Pointer to **NullableInt64** |  | [optional] 
+**TestopsId** | Pointer to **NullableInt64** | ID of the test case. Cannot be specified together with testopd_ids. | [optional] 
+**TestopsIds** | Pointer to **[]int64** | IDs of the test cases. Cannot be specified together with testopd_id. | [optional] 
 **Execution** | [**ResultExecution**](ResultExecution.md) |  | 
 **Fields** | Pointer to [**ResultCreateFields**](ResultCreateFields.md) |  | [optional] 
 **Attachments** | Pointer to **[]string** |  | [optional] 
@@ -143,6 +144,41 @@ HasTestopsId returns a boolean if a field has been set.
 `func (o *ResultCreate) UnsetTestopsId()`
 
 UnsetTestopsId ensures that no value is present for TestopsId, not even an explicit nil
+### GetTestopsIds
+
+`func (o *ResultCreate) GetTestopsIds() []int64`
+
+GetTestopsIds returns the TestopsIds field if non-nil, zero value otherwise.
+
+### GetTestopsIdsOk
+
+`func (o *ResultCreate) GetTestopsIdsOk() (*[]int64, bool)`
+
+GetTestopsIdsOk returns a tuple with the TestopsIds field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetTestopsIds
+
+`func (o *ResultCreate) SetTestopsIds(v []int64)`
+
+SetTestopsIds sets TestopsIds field to given value.
+
+### HasTestopsIds
+
+`func (o *ResultCreate) HasTestopsIds() bool`
+
+HasTestopsIds returns a boolean if a field has been set.
+
+### SetTestopsIdsNil
+
+`func (o *ResultCreate) SetTestopsIdsNil(b bool)`
+
+ SetTestopsIdsNil sets the value for TestopsIds to be an explicit nil
+
+### UnsetTestopsIds
+`func (o *ResultCreate) UnsetTestopsIds()`
+
+UnsetTestopsIds ensures that no value is present for TestopsIds, not even an explicit nil
 ### GetExecution
 
 `func (o *ResultCreate) GetExecution() ResultExecution`

--- a/qase-api-v2-client/model_result_create.go
+++ b/qase-api-v2-client/model_result_create.go
@@ -23,10 +23,13 @@ var _ MappedNullable = &ResultCreate{}
 // ResultCreate struct for ResultCreate
 type ResultCreate struct {
 	// If passed, used as an idempotency key
-	Id          *string                 `json:"id,omitempty"`
-	Title       string                  `json:"title"`
-	Signature   *string                 `json:"signature,omitempty"`
-	TestopsId   NullableInt64           `json:"testops_id,omitempty"`
+	Id        *string `json:"id,omitempty"`
+	Title     string  `json:"title"`
+	Signature *string `json:"signature,omitempty"`
+	// ID of the test case. Cannot be specified together with testopd_ids.
+	TestopsId NullableInt64 `json:"testops_id,omitempty"`
+	// IDs of the test cases. Cannot be specified together with testopd_id.
+	TestopsIds  []int64                 `json:"testops_ids,omitempty"`
 	Execution   ResultExecution         `json:"execution"`
 	Fields      *ResultCreateFields     `json:"fields,omitempty"`
 	Attachments []string                `json:"attachments,omitempty"`
@@ -191,6 +194,39 @@ func (o *ResultCreate) SetTestopsIdNil() {
 // UnsetTestopsId ensures that no value is present for TestopsId, not even an explicit nil
 func (o *ResultCreate) UnsetTestopsId() {
 	o.TestopsId.Unset()
+}
+
+// GetTestopsIds returns the TestopsIds field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *ResultCreate) GetTestopsIds() []int64 {
+	if o == nil {
+		var ret []int64
+		return ret
+	}
+	return o.TestopsIds
+}
+
+// GetTestopsIdsOk returns a tuple with the TestopsIds field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *ResultCreate) GetTestopsIdsOk() ([]int64, bool) {
+	if o == nil || IsNil(o.TestopsIds) {
+		return nil, false
+	}
+	return o.TestopsIds, true
+}
+
+// HasTestopsIds returns a boolean if a field has been set.
+func (o *ResultCreate) HasTestopsIds() bool {
+	if o != nil && !IsNil(o.TestopsIds) {
+		return true
+	}
+
+	return false
+}
+
+// SetTestopsIds gets a reference to the given []int64 and assigns it to the TestopsIds field.
+func (o *ResultCreate) SetTestopsIds(v []int64) {
+	o.TestopsIds = v
 }
 
 // GetExecution returns the Execution field value
@@ -558,6 +594,9 @@ func (o ResultCreate) ToMap() (map[string]interface{}, error) {
 	}
 	if o.TestopsId.IsSet() {
 		toSerialize["testops_id"] = o.TestopsId.Get()
+	}
+	if o.TestopsIds != nil {
+		toSerialize["testops_ids"] = o.TestopsIds
 	}
 	toSerialize["execution"] = o.Execution
 	if !IsNil(o.Fields) {


### PR DESCRIPTION
This pull request introduces new optional fields and methods to enhance the functionality of the `qase-api-client`. Key updates include adding support for including related entities in API responses, tracking the author of the last update (`UpdatedBy`), and recording elapsed time (`ElapsedTime`) for various models. Below is a detailed breakdown of the changes:

### API Enhancements
* Added support for including related entities (e.g., `external_issues`) in `GetCase` API requests via the new `Include` method in `ApiGetCaseRequest`. This includes updates to the `api_cases.go` file and corresponding documentation in `CasesAPI.md`. [[1]](diffhunk://#diff-5bf0bdd8627adf92a4ce1440b6883e5a60af4b6aa031722d3f35f810d49a327dR695-R701) [[2]](diffhunk://#diff-5bf0bdd8627adf92a4ce1440b6883e5a60af4b6aa031722d3f35f810d49a327dR757-R759) [[3]](diffhunk://#diff-30977677c18746bb9a4cd4b4c8fb39e28a1a9762a6bedfd79ea1b4346baf7a77L377-R377) [[4]](diffhunk://#diff-30977677c18746bb9a4cd4b4c8fb39e28a1a9762a6bedfd79ea1b4346baf7a77R398-R402) [[5]](diffhunk://#diff-30977677c18746bb9a4cd4b4c8fb39e28a1a9762a6bedfd79ea1b4346baf7a77R430)

### Metadata Tracking
* Introduced the `UpdatedBy` field to track the author of the last update in the following models:
  - `QqlTestCase` [[1]](diffhunk://#diff-cf80ae72088af700374e4b5591cc1c9708e6d5f5715d2367a97441714cb82d6bR34) [[2]](diffhunk://#diff-cf80ae72088af700374e4b5591cc1c9708e6d5f5715d2367a97441714cb82d6bR785-R809) [[3]](diffhunk://#diff-51b0b220dcd025229a1e49fcd5524edb7409c112360d9499ac2f568d12634681R55-R56) [[4]](diffhunk://#diff-51b0b220dcd025229a1e49fcd5524edb7409c112360d9499ac2f568d12634681R1004-R1035) [[5]](diffhunk://#diff-51b0b220dcd025229a1e49fcd5524edb7409c112360d9499ac2f568d12634681R1125-R1127)
  - `TestCaseQuery` [[1]](diffhunk://#diff-c5926f7df80bd44cde159f4a79b130d6fd4faa5d05fb5394f0fbf038c3b66387R34) [[2]](diffhunk://#diff-c5926f7df80bd44cde159f4a79b130d6fd4faa5d05fb5394f0fbf038c3b66387R785-R809) [[3]](diffhunk://#diff-269fa4263f2ebbf7c931a32ecd997dfdc75b0f426db7694b43fa7aef649ee97cR55-R56)
  - `SearchResponseAllOfResultEntities` [[1]](diffhunk://#diff-cfec830fd794d0c9ab4769fa918d06de4dc8d5e826f2d750d00e53c152849af4R55) [[2]](diffhunk://#diff-cfec830fd794d0c9ab4769fa918d06de4dc8d5e826f2d750d00e53c152849af4R1386-R1410)

### Time Tracking
* Added the `ElapsedTime` field to record elapsed time (in milliseconds) for the following models:
  - `Run` [[1]](diffhunk://#diff-5e2601ec643767687bb458dface92744a18585d783f3bc5f719ac378e3721c8aR18) [[2]](diffhunk://#diff-5e2601ec643767687bb458dface92744a18585d783f3bc5f719ac378e3721c8aR350-R374) [[3]](diffhunk://#diff-e4ce42772745f8890810eee1c04b446918aaf172a6870ba01da3098a9c1a2d9bR36-R37) [[4]](diffhunk://#diff-e4ce42772745f8890810eee1c04b446918aaf172a6870ba01da3098a9c1a2d9bR448-R479) [[5]](diffhunk://#diff-e4ce42772745f8890810eee1c04b446918aaf172a6870ba01da3098a9c1a2d9bR748-R750)
  - `RunQuery` [[1]](diffhunk://#diff-ed719b033cdadba6b868fd70f5b068135b776c2ed475b569c7fa9d0f4f60a47cR18) [[2]](diffhunk://#diff-ed719b033cdadba6b868fd70f5b068135b776c2ed475b569c7fa9d0f4f60a47cR345-R369) [[3]](diffhunk://#diff-87ca45e0438479e73a65480bf24accaa22491831a5bb6181337618c3e7f422e8R38-R39) [[4]](diffhunk://#diff-87ca45e0438479e73a65480bf24accaa22491831a5bb6181337618c3e7f422e8R445-R476) [[5]](diffhunk://#diff-87ca45e0438479e73a65480bf24accaa22491831a5bb6181337618c3e7f422e8R743-R745)
  - `SearchResponseAllOfResultEntities` [[1]](diffhunk://#diff-cfec830fd794d0c9ab4769fa918d06de4dc8d5e826f2d750d00e53c152849af4R18) [[2]](diffhunk://#diff-cfec830fd794d0c9ab4769fa918d06de4dc8d5e826f2d750d00e53c152849af4R381-R405)

These updates improve the API's flexibility and provide additional metadata for better tracking and reporting.