### PR TITLE
feat: add status filtering feature to TestOps reporting

### DIFF
--- a/examples/go/qase.config.json
+++ b/examples/go/qase.config.json
@@ -3,13 +3,17 @@
     "mode": "testops",
     "testops": {
       "api": {
-        "token": "YOUR_TOKEN"
+        "token": "YOUR_TOKEN",
+        "host": "qase.io"
       },
-  
-      "project": "project code",
-  
       "run": {
         "id": 1    
-      }
+      },
+      "defect": false,
+      "project": "project code",
+      "batch": {
+        "size": 100
+      },
+      "statusFilter": ["passed", "failed"]
     }
   }

--- a/pkg/qase-go/README.md
+++ b/pkg/qase-go/README.md
@@ -68,7 +68,8 @@ Create a `qase.config.json` file in your project root:
     "project": "your-project-code",
     "run": {
       "id": 123
-    }
+    },
+    "statusFilter": ["passed", "failed"]
   },
   "report": {
     "driver": "local",
@@ -113,6 +114,7 @@ export QASE_TESTOPS_RUN_ID=123
 You can create test runs using:
 
 **cURL:**
+
 ```bash
 curl --request POST \
      --url https://api.qase.io/v1/run/DEMO \
@@ -127,6 +129,7 @@ curl --request POST \
 ```
 
 **qasectl CLI:**
+
 ```bash
 qasectl testops run create --project PROJ --token <token> --title "Test Run 1"
 ```
@@ -136,6 +139,7 @@ qasectl testops run create --project PROJ --token <token> --title "Test Run 1"
 You can complete test runs using:
 
 **cURL:**
+
 ```bash
 curl --request POST \
      --url https://api.qase.io/v1/run/DEMO/1/complete \
@@ -144,16 +148,19 @@ curl --request POST \
 ```
 
 **qasectl CLI:**
+
 ```bash
 qasectl testops run complete --project PROJ --token <token> --id 1
 ```
 
 **GitHub Actions:**
+
 If you're using GitHub, we provide ready-to-use actions:
+
 - [Create test runs](https://github.com/qase-tms/gh-actions/run-create)
 - [Complete test runs](https://github.com/qase-tms/gh-actions/run-complete)
 
-#### Running Tests
+#### Test Execution
 
 ```bash
 # Run tests with reporting
@@ -181,6 +188,7 @@ go test -v ./...
 | `QASE_TESTOPS_API_HOST` | API host | `qase.io` |
 | `QASE_TESTOPS_DEFECT` | Auto-create defects for failed tests | `false` |
 | `QASE_TESTOPS_BATCH_SIZE` | Batch size for result uploads | `100` |
+| `QASE_TESTOPS_STATUS_FILTER` | Comma-separated list of statuses to exclude from TestOps | - |
 | `QASE_REPORT_DRIVER` | Report driver | `local` |
 | `QASE_REPORT_CONNECTION_PATH` | Local report path | `./build/qase-report` |
 | `QASE_REPORT_CONNECTION_FORMAT` | Report format | `json` |
@@ -191,7 +199,6 @@ For detailed documentation and advanced usage examples, see:
 
 - [Usage Guide](docs/usage.md) - Comprehensive usage documentation
 - [API Reference](https://godoc.org/github.com/qase-tms/qase-go) - Go package documentation
-
 
 ## License
 

--- a/pkg/qase-go/reporters/core.go
+++ b/pkg/qase-go/reporters/core.go
@@ -78,7 +78,7 @@ func (cr *CoreReporter) initializeReporter() error {
 			return fmt.Errorf("failed to create TestOps client: %w", err)
 		}
 
-		cr.reporter = NewTestOpsReporter(client, *cr.config.TestOps.Run.ID)
+		cr.reporter = NewTestOpsReporterWithConfig(client, *cr.config.TestOps.Run.ID, cr.config)
 	case "off":
 		return fmt.Errorf("reporting is disabled (mode: off)")
 	default:
@@ -104,7 +104,7 @@ func (cr *CoreReporter) initializeFallback() error {
 		if err != nil {
 			return fmt.Errorf("failed to create TestOps client for fallback: %w", err)
 		}
-		cr.fallback = NewTestOpsReporter(client, *cr.config.TestOps.Run.ID)
+		cr.fallback = NewTestOpsReporterWithConfig(client, *cr.config.TestOps.Run.ID, cr.config)
 	case "off":
 		// No fallback configured
 		cr.fallback = nil

--- a/pkg/qase-go/reporters/testops.go
+++ b/pkg/qase-go/reporters/testops.go
@@ -3,8 +3,10 @@ package reporters
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
+	"github.com/qase-tms/qase-go/pkg/qase-go/config"
 	"github.com/qase-tms/qase-go/pkg/qase-go/domain"
 )
 
@@ -16,18 +18,52 @@ type TestOpsClient interface {
 
 // TestOpsReporter handles sending test results to Qase TestOps
 type TestOpsReporter struct {
-	client  TestOpsClient
-	results []*domain.TestResult
-	runID   int64
+	client       TestOpsClient
+	results      []*domain.TestResult
+	runID        int64
+	config       *config.Config
+	statusFilter []string
 }
 
 // NewTestOpsReporter creates a new TestOps reporter with the given TestOps client and run ID
 func NewTestOpsReporter(client TestOpsClient, runID int64) *TestOpsReporter {
 	return &TestOpsReporter{
-		client:  client,
-		results: make([]*domain.TestResult, 0),
-		runID:   runID,
+		client:       client,
+		results:      make([]*domain.TestResult, 0),
+		runID:        runID,
+		config:       nil,
+		statusFilter: nil,
 	}
+}
+
+// NewTestOpsReporterWithConfig creates a new TestOps reporter with configuration for status filtering
+func NewTestOpsReporterWithConfig(client TestOpsClient, runID int64, cfg *config.Config) *TestOpsReporter {
+	statusFilter := cfg.TestOps.StatusFilter
+	return &TestOpsReporter{
+		client:       client,
+		results:      make([]*domain.TestResult, 0),
+		runID:        runID,
+		config:       cfg,
+		statusFilter: statusFilter,
+	}
+}
+
+// shouldIncludeResult checks if a result should be included based on status filter
+func (r *TestOpsReporter) shouldIncludeResult(result *domain.TestResult) bool {
+	// If no status filter is configured, include all results
+	if len(r.statusFilter) == 0 {
+		return true
+	}
+
+	// Check if the result's status should be excluded (is in the filter list)
+	resultStatus := string(result.Execution.Status)
+	for _, excludedStatus := range r.statusFilter {
+		if strings.EqualFold(resultStatus, excludedStatus) {
+			return false // Exclude this result
+		}
+	}
+
+	return true // Include this result
 }
 
 // AddResult adds a test result to the internal collection
@@ -38,6 +74,16 @@ func (r *TestOpsReporter) AddResult(result *domain.TestResult) error {
 
 	if result.Title == "" {
 		return fmt.Errorf("result title cannot be empty")
+	}
+
+	// Check if result should be included based on status filter
+	if !r.shouldIncludeResult(result) {
+		// Log that the result was filtered out (if debug is enabled)
+		if r.config != nil && r.config.Debug {
+			fmt.Printf("Filtered out result '%s' with status '%s' (excluded by statusFilter: %v)\n",
+				result.Title, result.Execution.Status, r.statusFilter)
+		}
+		return nil // Silently skip filtered results
 	}
 
 	// Set run ID


### PR DESCRIPTION
- Introduced a new `statusFilter` configuration option in `qase.config.json` to allow users to exclude specific test result statuses from being reported to Qase TestOps.
- Updated the `TestOpsReporter` to handle status filtering logic, ensuring that results matching the excluded statuses are not sent.
- Enhanced the documentation to include details on how to configure and use the status filtering feature, including examples and supported statuses.
- Added unit tests to validate the status filtering functionality and ensure correct behavior across various scenarios.

This feature improves the reporting capabilities by allowing users to focus on relevant test results and reduce noise in their reports.