### PR TITLE
feat: implement status mapping feature in Qase Go SDK

### DIFF
--- a/pkg/qase-go/README.md
+++ b/pkg/qase-go/README.md
@@ -12,6 +12,7 @@ Qase Go SDK provides comprehensive tools for integrating Go applications with Qa
 - **Rich Assertions**: Comprehensive assertion library with detailed error capture
 - **Test Organization**: Suite management and test metadata support
 - **Configuration Management**: Environment-based configuration with fallback support
+- **Status Mapping**: Transform test result statuses through configuration
 
 ## Installation
 
@@ -59,7 +60,10 @@ Create a `qase.config.json` file in your project root:
 {
   "mode": "testops",
   "fallback": "report",
-  
+  "statusMapping": {
+    "invalid": "failed",
+    "skipped": "passed"
+  },
   "testops": {
     "api": {
       "token": "your-api-token",
@@ -189,6 +193,7 @@ go test -v ./...
 | `QASE_TESTOPS_DEFECT` | Auto-create defects for failed tests | `false` |
 | `QASE_TESTOPS_BATCH_SIZE` | Batch size for result uploads | `100` |
 | `QASE_TESTOPS_STATUS_FILTER` | Comma-separated list of statuses to exclude from TestOps | - |
+| `QASE_STATUS_MAPPING` | Status mapping in format "from=to,from2=to2" | - |
 | `QASE_REPORT_DRIVER` | Report driver | `local` |
 | `QASE_REPORT_CONNECTION_PATH` | Local report path | `./build/qase-report` |
 | `QASE_REPORT_CONNECTION_FORMAT` | Report format | `json` |

--- a/pkg/qase-go/config/config_status_mapping_test.go
+++ b/pkg/qase-go/config/config_status_mapping_test.go
@@ -1,0 +1,244 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+// createValidConfig creates a valid configuration with the given status mapping
+func createValidConfig(statusMapping map[string]string) *Config {
+	return &Config{
+		Mode:         "report",
+		Fallback:     "off",
+		StatusMapping: statusMapping,
+		Report: ReportConfig{
+			Driver: "local",
+			Connection: ConnectionConfig{
+				Local: LocalConfig{
+					Path:   "./test-reports",
+					Format: "json",
+				},
+			},
+		},
+	}
+}
+
+func TestConfig_StatusMapping(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         *Config
+		expectedMapping map[string]string
+	}{
+		{
+			name: "empty status mapping",
+			config: &Config{
+				StatusMapping: nil,
+			},
+			expectedMapping: map[string]string{},
+		},
+		{
+			name: "valid status mapping",
+			config: &Config{
+				StatusMapping: map[string]string{
+					"invalid": "failed",
+					"skipped": "passed",
+				},
+			},
+			expectedMapping: map[string]string{
+				"invalid": "failed",
+				"skipped": "passed",
+			},
+		},
+		{
+			name: "single status mapping",
+			config: &Config{
+				StatusMapping: map[string]string{
+					"invalid": "failed",
+				},
+			},
+			expectedMapping: map[string]string{
+				"invalid": "failed",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mapping := tt.config.GetStatusMapping()
+			
+			if len(mapping) != len(tt.expectedMapping) {
+				t.Errorf("Expected mapping length %d, got %d", len(tt.expectedMapping), len(mapping))
+			}
+			
+			for from, to := range tt.expectedMapping {
+				if mapping[from] != to {
+					t.Errorf("Expected mapping %s->%s, got %s->%s", from, to, from, mapping[from])
+				}
+			}
+		})
+	}
+}
+
+func TestConfig_LoadFromEnvironment_StatusMapping(t *testing.T) {
+	tests := []struct {
+		name           string
+		envValue       string
+		expectedMapping map[string]string
+		expectError    bool
+	}{
+		{
+			name:           "valid env format",
+			envValue:       "invalid=failed,skipped=passed",
+			expectedMapping: map[string]string{
+				"invalid": "failed",
+				"skipped": "passed",
+			},
+			expectError: false,
+		},
+		{
+			name:           "single mapping",
+			envValue:       "invalid=failed",
+			expectedMapping: map[string]string{
+				"invalid": "failed",
+			},
+			expectError: false,
+		},
+		{
+			name:           "empty env value",
+			envValue:       "",
+			expectedMapping: map[string]string{},
+			expectError:    false,
+		},
+		{
+			name:           "whitespace handling",
+			envValue:       " invalid = failed , skipped = passed ",
+			expectedMapping: map[string]string{
+				"invalid": "failed",
+				"skipped": "passed",
+			},
+			expectError: false,
+		},
+		{
+			name:           "empty pairs",
+			envValue:       "invalid=failed,,skipped=passed,",
+			expectedMapping: map[string]string{
+				"invalid": "failed",
+				"skipped": "passed",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set environment variable
+			if tt.envValue != "" {
+				os.Setenv("QASE_STATUS_MAPPING", tt.envValue)
+				defer os.Unsetenv("QASE_STATUS_MAPPING")
+			}
+
+			config := NewConfig()
+			config.LoadFromEnvironment()
+
+			mapping := config.GetStatusMapping()
+
+			if len(mapping) != len(tt.expectedMapping) {
+				t.Errorf("Expected mapping length %d, got %d", len(tt.expectedMapping), len(mapping))
+			}
+
+			for from, to := range tt.expectedMapping {
+				if mapping[from] != to {
+					t.Errorf("Expected mapping %s->%s, got %s->%s", from, to, from, mapping[from])
+				}
+			}
+		})
+	}
+}
+
+func TestConfig_Validate_StatusMapping(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      *Config
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "valid status mapping",
+			config:      createValidConfig(map[string]string{"invalid": "failed", "skipped": "passed"}),
+			expectError: false,
+		},
+		{
+			name:        "empty status mapping",
+			config:      createValidConfig(map[string]string{}),
+			expectError: false,
+		},
+		{
+			name:        "nil status mapping",
+			config:      createValidConfig(nil),
+			expectError: false,
+		},
+		{
+			name:        "invalid source status",
+			config:      createValidConfig(map[string]string{"unknown": "failed"}),
+			expectError: true,
+			errorMsg:    "invalid source status",
+		},
+		{
+			name:        "invalid target status",
+			config:      createValidConfig(map[string]string{"failed": "unknown"}),
+			expectError: true,
+			errorMsg:    "invalid target status",
+		},
+		{
+			name:        "mapping to same status",
+			config:      createValidConfig(map[string]string{"failed": "failed"}),
+			expectError: true,
+			errorMsg:    "cannot map status",
+		},
+		{
+			name:        "case insensitive validation",
+			config:      createValidConfig(map[string]string{"INVALID": "FAILED"}),
+			expectError: false,
+		},
+		{
+			name:        "whitespace handling",
+			config:      createValidConfig(map[string]string{" invalid ": " failed "}),
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				} else if tt.errorMsg != "" && !containsString(err.Error(), tt.errorMsg) {
+					t.Errorf("Expected error message to contain '%s', got '%s'", tt.errorMsg, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// helper function to check if string contains substring
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 || 
+		(len(s) > len(substr) && (s[:len(substr)] == substr || 
+		s[len(s)-len(substr):] == substr || 
+		containsSubstring(s, substr))))
+}
+
+func containsSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/qase-go/docs/status_mapping.md
+++ b/pkg/qase-go/docs/status_mapping.md
@@ -1,0 +1,220 @@
+# Status Mapping
+
+The Qase Go SDK supports status mapping to transform test result statuses before reporting. This feature allows you to standardize statuses across different testing frameworks or adapt to specific reporting requirements.
+
+## Overview
+
+Status mapping is applied **centrally** in the main reporter class before any status filtering. This ensures consistent behavior across all reporters regardless of the testing framework used.
+
+## Available Statuses
+
+The following statuses are available for mapping:
+
+- `passed` - Test passed successfully
+- `failed` - Test failed due to assertion error  
+- `skipped` - Test was skipped
+- `blocked` - Test was blocked
+- `invalid` - Test failed due to non-assertion error (network issues, syntax errors)
+
+## Configuration
+
+### JSON Configuration
+
+Add `statusMapping` to your `qase.config.json`:
+
+```json
+{
+  "mode": "testops",
+  "fallback": "report",
+  "statusMapping": {
+    "invalid": "failed",
+    "skipped": "passed"
+  },
+  "testops": {
+    "api": {
+      "token": "your-api-token",
+      "host": "qase.io"
+    },
+    "project": "your-project-code",
+    "run": {
+      "id": 123
+    }
+  }
+}
+```
+
+### Environment Variable
+
+Use the `QASE_STATUS_MAPPING` environment variable:
+
+```bash
+export QASE_STATUS_MAPPING="invalid=failed,skipped=passed"
+```
+
+The format is `"from=to,from2=to2"` with comma-separated pairs.
+
+## Usage Examples
+
+### Example 1: Map Invalid Tests to Failed
+
+```json
+{
+  "statusMapping": {
+    "invalid": "failed"
+  }
+}
+```
+
+This will transform all tests with `invalid` status to `failed` status before reporting.
+
+### Example 2: Map Skipped Tests to Passed
+
+```json
+{
+  "statusMapping": {
+    "skipped": "passed"
+  }
+}
+```
+
+This will transform all tests with `skipped` status to `passed` status before reporting.
+
+### Example 3: Multiple Mappings
+
+```json
+{
+  "statusMapping": {
+    "invalid": "failed",
+    "skipped": "passed",
+    "blocked": "failed"
+  }
+}
+```
+
+This will apply multiple status transformations.
+
+### Example 4: Environment Variable with Multiple Mappings
+
+```bash
+export QASE_STATUS_MAPPING="invalid=failed,skipped=passed,blocked=failed"
+```
+
+## Programmatic Usage
+
+You can also create and use status mappings programmatically:
+
+```go
+package main
+
+import (
+    "github.com/qase-tms/qase-go/pkg/qase-go/domain"
+)
+
+func main() {
+    // Create mapping from map
+    mapping, err := domain.NewStatusMapping(map[string]string{
+        "invalid": "failed",
+        "skipped": "passed",
+    })
+    if err != nil {
+        panic(err)
+    }
+
+    // Apply mapping to a status
+    originalStatus := domain.StatusInvalid
+    mappedStatus := mapping.ApplyMapping(originalStatus)
+    // mappedStatus will be domain.StatusFailed
+
+    // Apply mapping to a test result
+    result := &domain.TestResult{
+        Title: "Test Case",
+        Execution: domain.TestExecution{
+            Status: domain.StatusInvalid,
+        },
+    }
+    
+    changed := mapping.ApplyMappingToResult(result)
+    // changed will be true, result.Execution.Status will be domain.StatusFailed
+}
+```
+
+## Validation
+
+The SDK validates status mappings to ensure:
+
+- Source and target statuses are valid
+- No mapping to the same status
+- Proper error messages for invalid configurations
+
+### Validation Examples
+
+```go
+// Valid mapping
+validMapping := map[string]string{
+    "invalid": "failed",
+    "skipped": "passed",
+}
+err := domain.ValidateMapping(validMapping)
+// err will be nil
+
+// Invalid mapping - unknown source status
+invalidMapping := map[string]string{
+    "unknown": "failed",
+}
+err := domain.ValidateMapping(invalidMapping)
+// err will contain validation error
+```
+
+## Important Notes
+
+- Status mapping is applied **before** status filtering
+- Mapping is applied **centrally** in the main reporter class
+- Works for **all reporters** regardless of testing framework
+- Invalid mappings are ignored with a warning
+- Status mapping is logged when debug mode is enabled
+- Case insensitive - `"INVALID"` and `"invalid"` are treated the same
+- Whitespace is trimmed automatically
+
+## Error Handling
+
+If an invalid status mapping is configured:
+
+1. **JSON Configuration**: The configuration validation will fail with a descriptive error message
+2. **Environment Variable**: Invalid mappings are ignored with a warning
+3. **Programmatic Usage**: Functions return errors for invalid configurations
+
+## Debugging
+
+Enable debug mode to see status mapping in action:
+
+```json
+{
+  "debug": true,
+  "statusMapping": {
+    "invalid": "failed"
+  }
+}
+```
+
+This will log status changes like:
+
+```
+Status mapped for test 'My Test': invalid -> failed
+```
+
+## Best Practices
+
+1. **Use consistent mappings** across your test suite
+2. **Document your mappings** for team members
+3. **Test your mappings** with sample data
+4. **Use environment variables** for different environments
+5. **Validate configurations** before deployment
+
+## Migration Guide
+
+If you're upgrading from a version without status mapping:
+
+1. No changes required - existing configurations will continue to work
+2. Add `statusMapping` field to your configuration as needed
+3. Test your mappings with a small subset of tests first
+4. Monitor logs to ensure mappings are applied correctly

--- a/pkg/qase-go/domain/status_mapping.go
+++ b/pkg/qase-go/domain/status_mapping.go
@@ -1,0 +1,166 @@
+package domain
+
+import (
+	"fmt"
+	"strings"
+)
+
+// StatusMapping represents a mapping from one status to another
+type StatusMapping map[TestResultStatus]TestResultStatus
+
+// NewStatusMapping creates a new status mapping from a map
+func NewStatusMapping(mapping map[string]string) (StatusMapping, error) {
+	result := make(StatusMapping)
+	
+	for from, to := range mapping {
+		fromStatus := TestResultStatus(strings.ToLower(strings.TrimSpace(from)))
+		toStatus := TestResultStatus(strings.ToLower(strings.TrimSpace(to)))
+		
+		// Validate source status
+		if !fromStatus.IsValid() {
+			return nil, fmt.Errorf("invalid source status '%s' in mapping", from)
+		}
+		
+		// Validate target status
+		if !toStatus.IsValid() {
+			return nil, fmt.Errorf("invalid target status '%s' in mapping", to)
+		}
+		
+		// Prevent mapping to the same status
+		if fromStatus == toStatus {
+			return nil, fmt.Errorf("cannot map status '%s' to itself", from)
+		}
+		
+		result[fromStatus] = toStatus
+	}
+	
+	return result, nil
+}
+
+// NewStatusMappingFromEnv creates a status mapping from environment variable format
+// Format: "invalid=failed,skipped=passed"
+func NewStatusMappingFromEnv(envValue string) (StatusMapping, error) {
+	if envValue == "" {
+		return nil, nil
+	}
+	
+	mapping := make(map[string]string)
+	
+	// Split by comma
+	pairs := strings.Split(envValue, ",")
+	for _, pair := range pairs {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		
+		// Split by equals sign
+		parts := strings.SplitN(pair, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid mapping format '%s', expected 'from=to'", pair)
+		}
+		
+		from := strings.TrimSpace(parts[0])
+		to := strings.TrimSpace(parts[1])
+		
+		if from == "" || to == "" {
+			return nil, fmt.Errorf("empty status in mapping '%s'", pair)
+		}
+		
+		mapping[from] = to
+	}
+	
+	return NewStatusMapping(mapping)
+}
+
+// ApplyMapping applies the status mapping to a test result status
+// Returns the mapped status if mapping exists, otherwise returns the original status
+func (sm StatusMapping) ApplyMapping(status TestResultStatus) TestResultStatus {
+	if mappedStatus, exists := sm[status]; exists {
+		return mappedStatus
+	}
+	return status
+}
+
+// ApplyMappingToResult applies the status mapping to a test result
+// Modifies the result in place and returns true if mapping was applied
+func (sm StatusMapping) ApplyMappingToResult(result *TestResult) bool {
+	if result == nil {
+		return false
+	}
+	
+	originalStatus := result.Execution.Status
+	mappedStatus := sm.ApplyMapping(originalStatus)
+	
+	if mappedStatus != originalStatus {
+		result.Execution.Status = mappedStatus
+		return true
+	}
+	
+	return false
+}
+
+// IsEmpty returns true if the mapping is empty
+func (sm StatusMapping) IsEmpty() bool {
+	return len(sm) == 0
+}
+
+// GetMappings returns a copy of the current mappings
+func (sm StatusMapping) GetMappings() map[TestResultStatus]TestResultStatus {
+	result := make(map[TestResultStatus]TestResultStatus)
+	for from, to := range sm {
+		result[from] = to
+	}
+	return result
+}
+
+// String returns a string representation of the mapping
+func (sm StatusMapping) String() string {
+	if sm.IsEmpty() {
+		return "{}"
+	}
+	
+	var parts []string
+	for from, to := range sm {
+		parts = append(parts, fmt.Sprintf("%s->%s", from, to))
+	}
+	
+	return fmt.Sprintf("{%s}", strings.Join(parts, ", "))
+}
+
+// ValidateMapping validates that all statuses in the mapping are valid
+func ValidateMapping(mapping map[string]string) error {
+	validStatuses := []string{"passed", "failed", "blocked", "skipped", "in_progress", "invalid"}
+	
+	for from, to := range mapping {
+		from = strings.ToLower(strings.TrimSpace(from))
+		to = strings.ToLower(strings.TrimSpace(to))
+		
+		// Check source status
+		if !contains(validStatuses, from) {
+			return fmt.Errorf("invalid source status '%s', must be one of: %s", from, strings.Join(validStatuses, ", "))
+		}
+		
+		// Check target status
+		if !contains(validStatuses, to) {
+			return fmt.Errorf("invalid target status '%s', must be one of: %s", to, strings.Join(validStatuses, ", "))
+		}
+		
+		// Prevent mapping to the same status
+		if from == to {
+			return fmt.Errorf("cannot map status '%s' to itself", from)
+		}
+	}
+	
+	return nil
+}
+
+// helper function to check if slice contains a value
+func contains(slice []string, value string) bool {
+	for _, item := range slice {
+		if item == value {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/qase-go/domain/status_mapping_demo_test.go
+++ b/pkg/qase-go/domain/status_mapping_demo_test.go
@@ -1,0 +1,85 @@
+package domain
+
+import (
+	"testing"
+)
+
+// TestStatusMappingDemo demonstrates the status mapping functionality
+func TestStatusMappingDemo(t *testing.T) {
+	t.Log("=== Qase Go Status Mapping Demo ===")
+
+	// Example 1: Create status mapping from map
+	t.Log("\n1. Creating status mapping from map:")
+	mapping, err := NewStatusMapping(map[string]string{
+		"invalid": "failed",
+		"skipped": "passed",
+	})
+	if err != nil {
+		t.Fatalf("Failed to create mapping: %v", err)
+	}
+	t.Logf("Created mapping: %s", mapping.String())
+
+	// Example 2: Apply mapping to different statuses
+	t.Log("\n2. Applying mapping to different statuses:")
+	testCases := []struct {
+		original TestResultStatus
+		expected TestResultStatus
+	}{
+		{StatusInvalid, StatusFailed},
+		{StatusSkipped, StatusPassed},
+		{StatusPassed, StatusPassed}, // Should remain unchanged
+		{StatusFailed, StatusFailed}, // Should remain unchanged
+	}
+
+	for _, tc := range testCases {
+		result := mapping.ApplyMapping(tc.original)
+		t.Logf("  %s -> %s (expected: %s)", tc.original, result, tc.expected)
+		if result != tc.expected {
+			t.Errorf("Expected %s, got %s", tc.expected, result)
+		}
+	}
+
+	// Example 3: Apply mapping to test result
+	t.Log("\n3. Applying mapping to test result:")
+	testResult := &TestResult{
+		Title: "Demo Test",
+		Execution: TestExecution{
+			Status: StatusInvalid,
+		},
+	}
+	t.Logf("Original status: %s", testResult.Execution.Status)
+	changed := mapping.ApplyMappingToResult(testResult)
+	t.Logf("Status changed: %v", changed)
+	t.Logf("New status: %s", testResult.Execution.Status)
+
+	// Example 4: Environment variable parsing
+	t.Log("\n4. Environment variable parsing:")
+	envMapping, err := NewStatusMappingFromEnv("blocked=failed,skipped=passed")
+	if err != nil {
+		t.Fatalf("Failed to parse env mapping: %v", err)
+	}
+	t.Logf("Env mapping: %s", envMapping.String())
+
+	// Example 5: Validation
+	t.Log("\n5. Validation examples:")
+	validMapping := map[string]string{
+		"invalid": "failed",
+		"skipped": "passed",
+	}
+	if err := ValidateMapping(validMapping); err != nil {
+		t.Errorf("Valid mapping failed validation: %v", err)
+	} else {
+		t.Log("Valid mapping passed validation")
+	}
+
+	invalidMapping := map[string]string{
+		"unknown": "failed", // Invalid source status
+	}
+	if err := ValidateMapping(invalidMapping); err != nil {
+		t.Logf("Invalid mapping correctly rejected: %v", err)
+	} else {
+		t.Error("Invalid mapping should have failed validation")
+	}
+
+	t.Log("\n=== Demo completed successfully ===")
+}

--- a/pkg/qase-go/domain/status_mapping_test.go
+++ b/pkg/qase-go/domain/status_mapping_test.go
@@ -1,0 +1,472 @@
+package domain
+
+import (
+	"testing"
+)
+
+func TestNewStatusMapping(t *testing.T) {
+	tests := []struct {
+		name        string
+		mapping     map[string]string
+		expectError bool
+		expectedLen int
+	}{
+		{
+			name: "valid mapping",
+			mapping: map[string]string{
+				"invalid": "failed",
+				"skipped": "passed",
+			},
+			expectError: false,
+			expectedLen: 2,
+		},
+		{
+			name: "empty mapping",
+			mapping: map[string]string{},
+			expectError: false,
+			expectedLen: 0,
+		},
+		{
+			name: "invalid source status",
+			mapping: map[string]string{
+				"unknown": "failed",
+			},
+			expectError: true,
+			expectedLen: 0,
+		},
+		{
+			name: "invalid target status",
+			mapping: map[string]string{
+				"failed": "unknown",
+			},
+			expectError: true,
+			expectedLen: 0,
+		},
+		{
+			name: "mapping to same status",
+			mapping: map[string]string{
+				"failed": "failed",
+			},
+			expectError: true,
+			expectedLen: 0,
+		},
+		{
+			name: "case insensitive mapping",
+			mapping: map[string]string{
+				"INVALID": "FAILED",
+				"Skipped": "Passed",
+			},
+			expectError: false,
+			expectedLen: 2,
+		},
+		{
+			name: "whitespace handling",
+			mapping: map[string]string{
+				" invalid ": " failed ",
+				" skipped ": " passed ",
+			},
+			expectError: false,
+			expectedLen: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mapping, err := NewStatusMapping(tt.mapping)
+			
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+				return
+			}
+			
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+			
+			if len(mapping) != tt.expectedLen {
+				t.Errorf("Expected mapping length %d, got %d", tt.expectedLen, len(mapping))
+			}
+		})
+	}
+}
+
+func TestNewStatusMappingFromEnv(t *testing.T) {
+	tests := []struct {
+		name        string
+		envValue    string
+		expectError bool
+		expectedLen int
+	}{
+		{
+			name:        "valid env format",
+			envValue:    "invalid=failed,skipped=passed",
+			expectError: false,
+			expectedLen: 2,
+		},
+		{
+			name:        "empty env value",
+			envValue:    "",
+			expectError: false,
+			expectedLen: 0,
+		},
+		{
+			name:        "single mapping",
+			envValue:    "invalid=failed",
+			expectError: false,
+			expectedLen: 1,
+		},
+		{
+			name:        "invalid format - no equals",
+			envValue:    "invalid,failed",
+			expectError: true,
+			expectedLen: 0,
+		},
+		{
+			name:        "invalid format - multiple equals",
+			envValue:    "invalid=failed=extra",
+			expectError: true,
+			expectedLen: 0,
+		},
+		{
+			name:        "empty status",
+			envValue:    "=failed",
+			expectError: true,
+			expectedLen: 0,
+		},
+		{
+			name:        "whitespace handling",
+			envValue:    " invalid = failed , skipped = passed ",
+			expectError: false,
+			expectedLen: 2,
+		},
+		{
+			name:        "empty pairs",
+			envValue:    "invalid=failed,,skipped=passed,",
+			expectError: false,
+			expectedLen: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mapping, err := NewStatusMappingFromEnv(tt.envValue)
+			
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+				return
+			}
+			
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+			
+			if mapping == nil {
+				if tt.expectedLen != 0 {
+					t.Errorf("Expected mapping length %d, got nil", tt.expectedLen)
+				}
+				return
+			}
+			
+			if len(mapping) != tt.expectedLen {
+				t.Errorf("Expected mapping length %d, got %d", tt.expectedLen, len(mapping))
+			}
+		})
+	}
+}
+
+func TestStatusMapping_ApplyMapping(t *testing.T) {
+	mapping, err := NewStatusMapping(map[string]string{
+		"invalid": "failed",
+		"skipped": "passed",
+	})
+	if err != nil {
+		t.Fatalf("Failed to create mapping: %v", err)
+	}
+
+	tests := []struct {
+		name           string
+		inputStatus    TestResultStatus
+		expectedStatus TestResultStatus
+	}{
+		{
+			name:           "mapped status - invalid to failed",
+			inputStatus:    StatusInvalid,
+			expectedStatus: StatusFailed,
+		},
+		{
+			name:           "mapped status - skipped to passed",
+			inputStatus:    StatusSkipped,
+			expectedStatus: StatusPassed,
+		},
+		{
+			name:           "unmapped status - passed",
+			inputStatus:    StatusPassed,
+			expectedStatus: StatusPassed,
+		},
+		{
+			name:           "unmapped status - failed",
+			inputStatus:    StatusFailed,
+			expectedStatus: StatusFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mapping.ApplyMapping(tt.inputStatus)
+			if result != tt.expectedStatus {
+				t.Errorf("Expected status %s, got %s", tt.expectedStatus, result)
+			}
+		})
+	}
+}
+
+func TestStatusMapping_ApplyMappingToResult(t *testing.T) {
+	mapping, err := NewStatusMapping(map[string]string{
+		"invalid": "failed",
+		"skipped": "passed",
+	})
+	if err != nil {
+		t.Fatalf("Failed to create mapping: %v", err)
+	}
+
+	tests := []struct {
+		name           string
+		inputStatus    TestResultStatus
+		expectedStatus TestResultStatus
+		expectedChange bool
+	}{
+		{
+			name:           "mapped status - invalid to failed",
+			inputStatus:    StatusInvalid,
+			expectedStatus: StatusFailed,
+			expectedChange: true,
+		},
+		{
+			name:           "mapped status - skipped to passed",
+			inputStatus:    StatusSkipped,
+			expectedStatus: StatusPassed,
+			expectedChange: true,
+		},
+		{
+			name:           "unmapped status - passed",
+			inputStatus:    StatusPassed,
+			expectedStatus: StatusPassed,
+			expectedChange: false,
+		},
+		{
+			name:           "nil result",
+			inputStatus:    StatusPassed,
+			expectedStatus: StatusPassed,
+			expectedChange: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result *TestResult
+			if tt.name != "nil result" {
+				result = &TestResult{
+					Title: "Test",
+					Execution: TestExecution{
+						Status: tt.inputStatus,
+					},
+				}
+			}
+
+			changed := mapping.ApplyMappingToResult(result)
+			if changed != tt.expectedChange {
+				t.Errorf("Expected change %v, got %v", tt.expectedChange, changed)
+			}
+
+			if result != nil && result.Execution.Status != tt.expectedStatus {
+				t.Errorf("Expected status %s, got %s", tt.expectedStatus, result.Execution.Status)
+			}
+		})
+	}
+}
+
+func TestStatusMapping_IsEmpty(t *testing.T) {
+	tests := []struct {
+		name     string
+		mapping  StatusMapping
+		expected bool
+	}{
+		{
+			name:     "empty mapping",
+			mapping:  StatusMapping{},
+			expected: true,
+		},
+		{
+			name: "non-empty mapping",
+			mapping: StatusMapping{
+				StatusInvalid: StatusFailed,
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.mapping.IsEmpty()
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestStatusMapping_GetMappings(t *testing.T) {
+	original := StatusMapping{
+		StatusInvalid: StatusFailed,
+		StatusSkipped: StatusPassed,
+	}
+
+	copy := original.GetMappings()
+
+	// Verify it's a copy, not the same reference
+	// We can't directly compare pointers, so we check if modifying one affects the other
+	original[StatusInvalid] = StatusPassed
+	if copy[StatusInvalid] == StatusPassed {
+		t.Error("GetMappings should return a copy, not the same reference")
+	}
+
+	// Verify contents are the same (before modification)
+	originalCopy := StatusMapping{
+		StatusInvalid: StatusFailed,
+		StatusSkipped: StatusPassed,
+	}
+	
+	if len(copy) != len(originalCopy) {
+		t.Errorf("Expected copy length %d, got %d", len(originalCopy), len(copy))
+	}
+
+	for from, to := range originalCopy {
+		if copy[from] != to {
+			t.Errorf("Expected mapping %s->%s, got %s->%s", from, to, from, copy[from])
+		}
+	}
+}
+
+func TestStatusMapping_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		mapping  StatusMapping
+		expected string
+	}{
+		{
+			name:     "empty mapping",
+			mapping:  StatusMapping{},
+			expected: "{}",
+		},
+		{
+			name: "single mapping",
+			mapping: StatusMapping{
+				StatusInvalid: StatusFailed,
+			},
+			expected: "{invalid->failed}",
+		},
+		{
+			name: "multiple mappings",
+			mapping: StatusMapping{
+				StatusInvalid: StatusFailed,
+				StatusSkipped: StatusPassed,
+			},
+			expected: "{invalid->failed, skipped->passed}", // Order may vary
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.mapping.String()
+			if tt.name == "empty mapping" {
+				if result != tt.expected {
+					t.Errorf("Expected %s, got %s", tt.expected, result)
+				}
+			} else {
+				// For non-empty mappings, just check it contains the expected elements
+				if result == "{}" {
+					t.Errorf("Expected non-empty string, got %s", result)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateMapping(t *testing.T) {
+	tests := []struct {
+		name        string
+		mapping     map[string]string
+		expectError bool
+	}{
+		{
+			name: "valid mapping",
+			mapping: map[string]string{
+				"invalid": "failed",
+				"skipped": "passed",
+			},
+			expectError: false,
+		},
+		{
+			name:        "empty mapping",
+			mapping:     map[string]string{},
+			expectError: false,
+		},
+		{
+			name: "invalid source status",
+			mapping: map[string]string{
+				"unknown": "failed",
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid target status",
+			mapping: map[string]string{
+				"failed": "unknown",
+			},
+			expectError: true,
+		},
+		{
+			name: "mapping to same status",
+			mapping: map[string]string{
+				"failed": "failed",
+			},
+			expectError: true,
+		},
+		{
+			name: "case insensitive validation",
+			mapping: map[string]string{
+				"INVALID": "FAILED",
+			},
+			expectError: false,
+		},
+		{
+			name: "whitespace handling",
+			mapping: map[string]string{
+				" invalid ": " failed ",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateMapping(tt.mapping)
+			
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/qase-go/reporters/core_status_mapping_test.go
+++ b/pkg/qase-go/reporters/core_status_mapping_test.go
@@ -1,0 +1,355 @@
+package reporters
+
+import (
+	"testing"
+
+	"github.com/qase-tms/qase-go/pkg/qase-go/config"
+	"github.com/qase-tms/qase-go/pkg/qase-go/domain"
+)
+
+func TestCoreReporter_StatusMapping(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         *config.Config
+		inputStatus    domain.TestResultStatus
+		expectedStatus domain.TestResultStatus
+		expectMapping  bool
+	}{
+		{
+			name: "no status mapping configured",
+			config: &config.Config{
+				Mode:     "report",
+				Fallback: "off",
+				Report: config.ReportConfig{
+					Driver: "local",
+					Connection: config.ConnectionConfig{
+						Local: config.LocalConfig{
+							Path:   "./test-reports",
+							Format: "json",
+						},
+					},
+				},
+			},
+			inputStatus:    domain.StatusInvalid,
+			expectedStatus: domain.StatusInvalid,
+			expectMapping:  false,
+		},
+		{
+			name: "status mapping - invalid to failed",
+			config: &config.Config{
+				Mode:     "report",
+				Fallback: "off",
+				StatusMapping: map[string]string{
+					"invalid": "failed",
+				},
+				Report: config.ReportConfig{
+					Driver: "local",
+					Connection: config.ConnectionConfig{
+						Local: config.LocalConfig{
+							Path:   "./test-reports",
+							Format: "json",
+						},
+					},
+				},
+			},
+			inputStatus:    domain.StatusInvalid,
+			expectedStatus: domain.StatusFailed,
+			expectMapping:  true,
+		},
+		{
+			name: "status mapping - skipped to passed",
+			config: &config.Config{
+				Mode:     "report",
+				Fallback: "off",
+				StatusMapping: map[string]string{
+					"skipped": "passed",
+				},
+				Report: config.ReportConfig{
+					Driver: "local",
+					Connection: config.ConnectionConfig{
+						Local: config.LocalConfig{
+							Path:   "./test-reports",
+							Format: "json",
+						},
+					},
+				},
+			},
+			inputStatus:    domain.StatusSkipped,
+			expectedStatus: domain.StatusPassed,
+			expectMapping:  true,
+		},
+		{
+			name: "status mapping - unmapped status",
+			config: &config.Config{
+				Mode:     "report",
+				Fallback: "off",
+				StatusMapping: map[string]string{
+					"invalid": "failed",
+				},
+				Report: config.ReportConfig{
+					Driver: "local",
+					Connection: config.ConnectionConfig{
+						Local: config.LocalConfig{
+							Path:   "./test-reports",
+							Format: "json",
+						},
+					},
+				},
+			},
+			inputStatus:    domain.StatusPassed,
+			expectedStatus: domain.StatusPassed,
+			expectMapping:  false,
+		},
+		{
+			name: "multiple status mappings",
+			config: &config.Config{
+				Mode:     "report",
+				Fallback: "off",
+				StatusMapping: map[string]string{
+					"invalid": "failed",
+					"skipped": "passed",
+				},
+				Report: config.ReportConfig{
+					Driver: "local",
+					Connection: config.ConnectionConfig{
+						Local: config.LocalConfig{
+							Path:   "./test-reports",
+							Format: "json",
+						},
+					},
+				},
+			},
+			inputStatus:    domain.StatusSkipped,
+			expectedStatus: domain.StatusPassed,
+			expectMapping:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create core reporter
+			reporter, err := NewCoreReporter(tt.config)
+			if err != nil {
+				t.Fatalf("Failed to create core reporter: %v", err)
+			}
+
+			// Create test result
+			result := &domain.TestResult{
+				Title: "Test Case",
+				Execution: domain.TestExecution{
+					Status: tt.inputStatus,
+				},
+			}
+
+			// Add result to reporter
+			err = reporter.AddResult(result)
+			if err != nil {
+				t.Fatalf("Failed to add result: %v", err)
+			}
+
+			// Verify status mapping
+			if result.Execution.Status != tt.expectedStatus {
+				t.Errorf("Expected status %s, got %s", tt.expectedStatus, result.Execution.Status)
+			}
+
+			// Verify mapping was applied
+			statusMapping := reporter.GetStatusMapping()
+			if tt.expectMapping && statusMapping.IsEmpty() {
+				t.Error("Expected status mapping to be configured")
+			}
+		})
+	}
+}
+
+func TestCoreReporter_StatusMapping_InvalidConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      *config.Config
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "invalid source status in mapping",
+			config: &config.Config{
+				Mode:     "report",
+				Fallback: "off",
+				StatusMapping: map[string]string{
+					"unknown": "failed",
+				},
+				Report: config.ReportConfig{
+					Driver: "local",
+					Connection: config.ConnectionConfig{
+						Local: config.LocalConfig{
+							Path:   "./test-reports",
+							Format: "json",
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorMsg:    "invalid status mapping configuration",
+		},
+		{
+			name: "invalid target status in mapping",
+			config: &config.Config{
+				Mode:     "report",
+				Fallback: "off",
+				StatusMapping: map[string]string{
+					"failed": "unknown",
+				},
+				Report: config.ReportConfig{
+					Driver: "local",
+					Connection: config.ConnectionConfig{
+						Local: config.LocalConfig{
+							Path:   "./test-reports",
+							Format: "json",
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorMsg:    "invalid status mapping configuration",
+		},
+		{
+			name: "mapping to same status",
+			config: &config.Config{
+				Mode:     "report",
+				Fallback: "off",
+				StatusMapping: map[string]string{
+					"failed": "failed",
+				},
+				Report: config.ReportConfig{
+					Driver: "local",
+					Connection: config.ConnectionConfig{
+						Local: config.LocalConfig{
+							Path:   "./test-reports",
+							Format: "json",
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorMsg:    "invalid status mapping configuration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create core reporter
+			_, err := NewCoreReporter(tt.config)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				} else if tt.errorMsg != "" && !contains(err.Error(), tt.errorMsg) {
+					t.Errorf("Expected error message to contain '%s', got '%s'", tt.errorMsg, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestCoreReporter_GetStatusMapping(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         *config.Config
+		expectedEmpty  bool
+		expectedMappings map[domain.TestResultStatus]domain.TestResultStatus
+	}{
+		{
+			name: "no status mapping",
+			config: &config.Config{
+				Mode:     "report",
+				Fallback: "off",
+				Report: config.ReportConfig{
+					Driver: "local",
+					Connection: config.ConnectionConfig{
+						Local: config.LocalConfig{
+							Path:   "./test-reports",
+							Format: "json",
+						},
+					},
+				},
+			},
+			expectedEmpty: true,
+		},
+		{
+			name: "status mapping configured",
+			config: &config.Config{
+				Mode:     "report",
+				Fallback: "off",
+				StatusMapping: map[string]string{
+					"invalid": "failed",
+					"skipped": "passed",
+				},
+				Report: config.ReportConfig{
+					Driver: "local",
+					Connection: config.ConnectionConfig{
+						Local: config.LocalConfig{
+							Path:   "./test-reports",
+							Format: "json",
+						},
+					},
+				},
+			},
+			expectedEmpty: false,
+			expectedMappings: map[domain.TestResultStatus]domain.TestResultStatus{
+				domain.StatusInvalid: domain.StatusFailed,
+				domain.StatusSkipped: domain.StatusPassed,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create core reporter
+			reporter, err := NewCoreReporter(tt.config)
+			if err != nil {
+				t.Fatalf("Failed to create core reporter: %v", err)
+			}
+
+			// Get status mapping
+			mapping := reporter.GetStatusMapping()
+
+			// Verify empty state
+			if mapping.IsEmpty() != tt.expectedEmpty {
+				t.Errorf("Expected empty %v, got %v", tt.expectedEmpty, mapping.IsEmpty())
+			}
+
+			// Verify mappings if not empty
+			if !tt.expectedEmpty && tt.expectedMappings != nil {
+				actualMappings := mapping.GetMappings()
+				if len(actualMappings) != len(tt.expectedMappings) {
+					t.Errorf("Expected %d mappings, got %d", len(tt.expectedMappings), len(actualMappings))
+				}
+
+				for from, to := range tt.expectedMappings {
+					if actualMappings[from] != to {
+						t.Errorf("Expected mapping %s->%s, got %s->%s", from, to, from, actualMappings[from])
+					}
+				}
+			}
+		})
+	}
+}
+
+// helper function to check if string contains substring
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 || 
+		(len(s) > len(substr) && (s[:len(substr)] == substr || 
+		s[len(s)-len(substr):] == substr || 
+		containsSubstring(s, substr))))
+}
+
+func containsSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
- Added a new `statusMapping` configuration option in `qase.config.json` to allow users to transform test result statuses before reporting.
- Introduced methods for creating and applying status mappings, including validation to ensure correct configurations.
- Enhanced the `CoreReporter` to apply status mappings when adding test results, improving reporting accuracy.
- Updated documentation to include details on how to configure and use the status mapping feature, with examples and validation rules.
- Added comprehensive unit tests to validate the status mapping functionality and ensure correct behavior across various scenarios.

This feature enhances the flexibility of the reporting process by allowing users to standardize test result statuses across different testing frameworks.