### PR TITLE
chore: update API clients to latest specification

### DIFF
--- a/qase-api-client/docs/TestStepResult.md
+++ b/qase-api-client/docs/TestStepResult.md
@@ -6,8 +6,12 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Status** | Pointer to **int32** | 1 - passed, 2 - failed, 3 - blocked, 5 - skipped, 7 - in_progress | [optional] 
 **Position** | Pointer to **int32** |  | [optional] 
+**Comment** | Pointer to **string** | Comment left for the step. | [optional] 
+**StartTime** | Pointer to **NullableInt64** | Unix timestamp of the step start time. | [optional] 
+**EndTime** | Pointer to **NullableInt64** | Unix timestamp of the step end time. | [optional] 
+**DurationMs** | Pointer to **NullableInt64** | Step duration in milliseconds. | [optional] 
 **Attachments** | Pointer to [**[]Attachment**](Attachment.md) |  | [optional] 
-**Steps** | Pointer to **[]map[string]interface{}** | Nested steps results will be here. The same structure is used for them for them. | [optional] 
+**Steps** | Pointer to [**[]TestStepResult**](TestStepResult.md) | Nested steps results will be here. The same structure is used for them. | [optional] 
 
 ## Methods
 
@@ -78,6 +82,136 @@ SetPosition sets Position field to given value.
 
 HasPosition returns a boolean if a field has been set.
 
+### GetComment
+
+`func (o *TestStepResult) GetComment() string`
+
+GetComment returns the Comment field if non-nil, zero value otherwise.
+
+### GetCommentOk
+
+`func (o *TestStepResult) GetCommentOk() (*string, bool)`
+
+GetCommentOk returns a tuple with the Comment field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetComment
+
+`func (o *TestStepResult) SetComment(v string)`
+
+SetComment sets Comment field to given value.
+
+### HasComment
+
+`func (o *TestStepResult) HasComment() bool`
+
+HasComment returns a boolean if a field has been set.
+
+### GetStartTime
+
+`func (o *TestStepResult) GetStartTime() int64`
+
+GetStartTime returns the StartTime field if non-nil, zero value otherwise.
+
+### GetStartTimeOk
+
+`func (o *TestStepResult) GetStartTimeOk() (*int64, bool)`
+
+GetStartTimeOk returns a tuple with the StartTime field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetStartTime
+
+`func (o *TestStepResult) SetStartTime(v int64)`
+
+SetStartTime sets StartTime field to given value.
+
+### HasStartTime
+
+`func (o *TestStepResult) HasStartTime() bool`
+
+HasStartTime returns a boolean if a field has been set.
+
+### SetStartTimeNil
+
+`func (o *TestStepResult) SetStartTimeNil(b bool)`
+
+ SetStartTimeNil sets the value for StartTime to be an explicit nil
+
+### UnsetStartTime
+`func (o *TestStepResult) UnsetStartTime()`
+
+UnsetStartTime ensures that no value is present for StartTime, not even an explicit nil
+### GetEndTime
+
+`func (o *TestStepResult) GetEndTime() int64`
+
+GetEndTime returns the EndTime field if non-nil, zero value otherwise.
+
+### GetEndTimeOk
+
+`func (o *TestStepResult) GetEndTimeOk() (*int64, bool)`
+
+GetEndTimeOk returns a tuple with the EndTime field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetEndTime
+
+`func (o *TestStepResult) SetEndTime(v int64)`
+
+SetEndTime sets EndTime field to given value.
+
+### HasEndTime
+
+`func (o *TestStepResult) HasEndTime() bool`
+
+HasEndTime returns a boolean if a field has been set.
+
+### SetEndTimeNil
+
+`func (o *TestStepResult) SetEndTimeNil(b bool)`
+
+ SetEndTimeNil sets the value for EndTime to be an explicit nil
+
+### UnsetEndTime
+`func (o *TestStepResult) UnsetEndTime()`
+
+UnsetEndTime ensures that no value is present for EndTime, not even an explicit nil
+### GetDurationMs
+
+`func (o *TestStepResult) GetDurationMs() int64`
+
+GetDurationMs returns the DurationMs field if non-nil, zero value otherwise.
+
+### GetDurationMsOk
+
+`func (o *TestStepResult) GetDurationMsOk() (*int64, bool)`
+
+GetDurationMsOk returns a tuple with the DurationMs field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetDurationMs
+
+`func (o *TestStepResult) SetDurationMs(v int64)`
+
+SetDurationMs sets DurationMs field to given value.
+
+### HasDurationMs
+
+`func (o *TestStepResult) HasDurationMs() bool`
+
+HasDurationMs returns a boolean if a field has been set.
+
+### SetDurationMsNil
+
+`func (o *TestStepResult) SetDurationMsNil(b bool)`
+
+ SetDurationMsNil sets the value for DurationMs to be an explicit nil
+
+### UnsetDurationMs
+`func (o *TestStepResult) UnsetDurationMs()`
+
+UnsetDurationMs ensures that no value is present for DurationMs, not even an explicit nil
 ### GetAttachments
 
 `func (o *TestStepResult) GetAttachments() []Attachment`
@@ -105,20 +239,20 @@ HasAttachments returns a boolean if a field has been set.
 
 ### GetSteps
 
-`func (o *TestStepResult) GetSteps() []map[string]interface{}`
+`func (o *TestStepResult) GetSteps() []TestStepResult`
 
 GetSteps returns the Steps field if non-nil, zero value otherwise.
 
 ### GetStepsOk
 
-`func (o *TestStepResult) GetStepsOk() (*[]map[string]interface{}, bool)`
+`func (o *TestStepResult) GetStepsOk() (*[]TestStepResult, bool)`
 
 GetStepsOk returns a tuple with the Steps field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetSteps
 
-`func (o *TestStepResult) SetSteps(v []map[string]interface{})`
+`func (o *TestStepResult) SetSteps(v []TestStepResult)`
 
 SetSteps sets Steps field to given value.
 

--- a/qase-api-client/model_test_step_result.go
+++ b/qase-api-client/model_test_step_result.go
@@ -23,10 +23,18 @@ type TestStepResult struct {
 	// 1 - passed, 2 - failed, 3 - blocked, 5 - skipped, 7 - in_progress
 	Status *int32 `json:"status,omitempty"`
 	// Deprecated
-	Position    *int32       `json:"position,omitempty"`
-	Attachments []Attachment `json:"attachments,omitempty"`
-	// Nested steps results will be here. The same structure is used for them for them.
-	Steps []map[string]interface{} `json:"steps,omitempty"`
+	Position *int32 `json:"position,omitempty"`
+	// Comment left for the step.
+	Comment *string `json:"comment,omitempty"`
+	// Unix timestamp of the step start time.
+	StartTime NullableInt64 `json:"start_time,omitempty"`
+	// Unix timestamp of the step end time.
+	EndTime NullableInt64 `json:"end_time,omitempty"`
+	// Step duration in milliseconds.
+	DurationMs  NullableInt64 `json:"duration_ms,omitempty"`
+	Attachments []Attachment  `json:"attachments,omitempty"`
+	// Nested steps results will be here. The same structure is used for them.
+	Steps []TestStepResult `json:"steps,omitempty"`
 }
 
 // NewTestStepResult instantiates a new TestStepResult object
@@ -113,6 +121,167 @@ func (o *TestStepResult) SetPosition(v int32) {
 	o.Position = &v
 }
 
+// GetComment returns the Comment field value if set, zero value otherwise.
+func (o *TestStepResult) GetComment() string {
+	if o == nil || IsNil(o.Comment) {
+		var ret string
+		return ret
+	}
+	return *o.Comment
+}
+
+// GetCommentOk returns a tuple with the Comment field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TestStepResult) GetCommentOk() (*string, bool) {
+	if o == nil || IsNil(o.Comment) {
+		return nil, false
+	}
+	return o.Comment, true
+}
+
+// HasComment returns a boolean if a field has been set.
+func (o *TestStepResult) HasComment() bool {
+	if o != nil && !IsNil(o.Comment) {
+		return true
+	}
+
+	return false
+}
+
+// SetComment gets a reference to the given string and assigns it to the Comment field.
+func (o *TestStepResult) SetComment(v string) {
+	o.Comment = &v
+}
+
+// GetStartTime returns the StartTime field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *TestStepResult) GetStartTime() int64 {
+	if o == nil || IsNil(o.StartTime.Get()) {
+		var ret int64
+		return ret
+	}
+	return *o.StartTime.Get()
+}
+
+// GetStartTimeOk returns a tuple with the StartTime field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *TestStepResult) GetStartTimeOk() (*int64, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.StartTime.Get(), o.StartTime.IsSet()
+}
+
+// HasStartTime returns a boolean if a field has been set.
+func (o *TestStepResult) HasStartTime() bool {
+	if o != nil && o.StartTime.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetStartTime gets a reference to the given NullableInt64 and assigns it to the StartTime field.
+func (o *TestStepResult) SetStartTime(v int64) {
+	o.StartTime.Set(&v)
+}
+
+// SetStartTimeNil sets the value for StartTime to be an explicit nil
+func (o *TestStepResult) SetStartTimeNil() {
+	o.StartTime.Set(nil)
+}
+
+// UnsetStartTime ensures that no value is present for StartTime, not even an explicit nil
+func (o *TestStepResult) UnsetStartTime() {
+	o.StartTime.Unset()
+}
+
+// GetEndTime returns the EndTime field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *TestStepResult) GetEndTime() int64 {
+	if o == nil || IsNil(o.EndTime.Get()) {
+		var ret int64
+		return ret
+	}
+	return *o.EndTime.Get()
+}
+
+// GetEndTimeOk returns a tuple with the EndTime field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *TestStepResult) GetEndTimeOk() (*int64, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.EndTime.Get(), o.EndTime.IsSet()
+}
+
+// HasEndTime returns a boolean if a field has been set.
+func (o *TestStepResult) HasEndTime() bool {
+	if o != nil && o.EndTime.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetEndTime gets a reference to the given NullableInt64 and assigns it to the EndTime field.
+func (o *TestStepResult) SetEndTime(v int64) {
+	o.EndTime.Set(&v)
+}
+
+// SetEndTimeNil sets the value for EndTime to be an explicit nil
+func (o *TestStepResult) SetEndTimeNil() {
+	o.EndTime.Set(nil)
+}
+
+// UnsetEndTime ensures that no value is present for EndTime, not even an explicit nil
+func (o *TestStepResult) UnsetEndTime() {
+	o.EndTime.Unset()
+}
+
+// GetDurationMs returns the DurationMs field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *TestStepResult) GetDurationMs() int64 {
+	if o == nil || IsNil(o.DurationMs.Get()) {
+		var ret int64
+		return ret
+	}
+	return *o.DurationMs.Get()
+}
+
+// GetDurationMsOk returns a tuple with the DurationMs field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *TestStepResult) GetDurationMsOk() (*int64, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.DurationMs.Get(), o.DurationMs.IsSet()
+}
+
+// HasDurationMs returns a boolean if a field has been set.
+func (o *TestStepResult) HasDurationMs() bool {
+	if o != nil && o.DurationMs.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetDurationMs gets a reference to the given NullableInt64 and assigns it to the DurationMs field.
+func (o *TestStepResult) SetDurationMs(v int64) {
+	o.DurationMs.Set(&v)
+}
+
+// SetDurationMsNil sets the value for DurationMs to be an explicit nil
+func (o *TestStepResult) SetDurationMsNil() {
+	o.DurationMs.Set(nil)
+}
+
+// UnsetDurationMs ensures that no value is present for DurationMs, not even an explicit nil
+func (o *TestStepResult) UnsetDurationMs() {
+	o.DurationMs.Unset()
+}
+
 // GetAttachments returns the Attachments field value if set, zero value otherwise.
 func (o *TestStepResult) GetAttachments() []Attachment {
 	if o == nil || IsNil(o.Attachments) {
@@ -146,9 +315,9 @@ func (o *TestStepResult) SetAttachments(v []Attachment) {
 }
 
 // GetSteps returns the Steps field value if set, zero value otherwise.
-func (o *TestStepResult) GetSteps() []map[string]interface{} {
+func (o *TestStepResult) GetSteps() []TestStepResult {
 	if o == nil || IsNil(o.Steps) {
-		var ret []map[string]interface{}
+		var ret []TestStepResult
 		return ret
 	}
 	return o.Steps
@@ -156,7 +325,7 @@ func (o *TestStepResult) GetSteps() []map[string]interface{} {
 
 // GetStepsOk returns a tuple with the Steps field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *TestStepResult) GetStepsOk() ([]map[string]interface{}, bool) {
+func (o *TestStepResult) GetStepsOk() ([]TestStepResult, bool) {
 	if o == nil || IsNil(o.Steps) {
 		return nil, false
 	}
@@ -172,8 +341,8 @@ func (o *TestStepResult) HasSteps() bool {
 	return false
 }
 
-// SetSteps gets a reference to the given []map[string]interface{} and assigns it to the Steps field.
-func (o *TestStepResult) SetSteps(v []map[string]interface{}) {
+// SetSteps gets a reference to the given []TestStepResult and assigns it to the Steps field.
+func (o *TestStepResult) SetSteps(v []TestStepResult) {
 	o.Steps = v
 }
 
@@ -192,6 +361,18 @@ func (o TestStepResult) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.Position) {
 		toSerialize["position"] = o.Position
+	}
+	if !IsNil(o.Comment) {
+		toSerialize["comment"] = o.Comment
+	}
+	if o.StartTime.IsSet() {
+		toSerialize["start_time"] = o.StartTime.Get()
+	}
+	if o.EndTime.IsSet() {
+		toSerialize["end_time"] = o.EndTime.Get()
+	}
+	if o.DurationMs.IsSet() {
+		toSerialize["duration_ms"] = o.DurationMs.Get()
 	}
 	if !IsNil(o.Attachments) {
 		toSerialize["attachments"] = o.Attachments


### PR DESCRIPTION
## Summary

Updated the v1 API client to the latest OpenAPI specification.

### Targets updated
- v1 (`qase-api-client`): no version file (Go module, no bump)

### Changes
`TestStepResult` model now includes the fields actually returned by the public API v1:
- `Comment` (*string)
- `StartTime`, `EndTime`, `DurationMs` (NullableInt64)
- nested `Steps` now typed recursively as `[]TestStepResult`

### Protected files (skipped)
- `configuration.go`, `client.go`, `model_configuration.go`, `model_configuration_group.go`, `model_search_response_all_of_result_entities.go`

### Warnings
None