### PR TITLE
chore: update API clients to latest specification

### DIFF
--- a/qase-api-client/docs/TestCase.md
+++ b/qase-api-client/docs/TestCase.md
@@ -17,8 +17,8 @@ Name | Type | Description | Notes
 **IsFlaky** | Pointer to **int32** |  | [optional] 
 **Behavior** | Pointer to **int32** |  | [optional] 
 **Automation** | Pointer to **int32** | Deprecated, use &#x60;isManual&#x60; and &#x60;isToBeAutomated&#x60; instead. Encodes the test case automation state as a single integer: &#x60;0&#x60; &#x3D; manual, &#x60;1&#x60; &#x3D; manual planned to be automated, &#x60;2&#x60; &#x3D; automated. | [optional] 
-**IsManual** | Pointer to **int32** | &#x60;1&#x60; if the case is manual, &#x60;0&#x60; if it is automated. Combined with &#x60;isToBeAutomated&#x60;, replaces the deprecated &#x60;automation&#x60; field. | [optional] 
-**IsToBeAutomated** | Pointer to **int32** | &#x60;1&#x60; if a manual case is planned to be automated, &#x60;0&#x60; otherwise. Only meaningful when &#x60;isManual &#x3D; 1&#x60;; ignored when &#x60;isManual &#x3D; 0&#x60;. | [optional] 
+**IsManual** | Pointer to **bool** | &#x60;true&#x60; if the case is manual, &#x60;false&#x60; if it is automated. Combined with &#x60;isToBeAutomated&#x60;, replaces the deprecated &#x60;automation&#x60; field. | [optional] 
+**IsToBeAutomated** | Pointer to **bool** | &#x60;true&#x60; if a manual case is planned to be automated, &#x60;false&#x60; otherwise. Only meaningful when &#x60;isManual&#x60; is &#x60;true&#x60;; ignored when &#x60;isManual&#x60; is &#x60;false&#x60;. | [optional] 
 **Status** | Pointer to **int32** |  | [optional] 
 **MilestoneId** | Pointer to **NullableInt64** |  | [optional] 
 **SuiteId** | Pointer to **NullableInt64** |  | [optional] 
@@ -414,20 +414,20 @@ HasAutomation returns a boolean if a field has been set.
 
 ### GetIsManual
 
-`func (o *TestCase) GetIsManual() int32`
+`func (o *TestCase) GetIsManual() bool`
 
 GetIsManual returns the IsManual field if non-nil, zero value otherwise.
 
 ### GetIsManualOk
 
-`func (o *TestCase) GetIsManualOk() (*int32, bool)`
+`func (o *TestCase) GetIsManualOk() (*bool, bool)`
 
 GetIsManualOk returns a tuple with the IsManual field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetIsManual
 
-`func (o *TestCase) SetIsManual(v int32)`
+`func (o *TestCase) SetIsManual(v bool)`
 
 SetIsManual sets IsManual field to given value.
 
@@ -439,20 +439,20 @@ HasIsManual returns a boolean if a field has been set.
 
 ### GetIsToBeAutomated
 
-`func (o *TestCase) GetIsToBeAutomated() int32`
+`func (o *TestCase) GetIsToBeAutomated() bool`
 
 GetIsToBeAutomated returns the IsToBeAutomated field if non-nil, zero value otherwise.
 
 ### GetIsToBeAutomatedOk
 
-`func (o *TestCase) GetIsToBeAutomatedOk() (*int32, bool)`
+`func (o *TestCase) GetIsToBeAutomatedOk() (*bool, bool)`
 
 GetIsToBeAutomatedOk returns a tuple with the IsToBeAutomated field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetIsToBeAutomated
 
-`func (o *TestCase) SetIsToBeAutomated(v int32)`
+`func (o *TestCase) SetIsToBeAutomated(v bool)`
 
 SetIsToBeAutomated sets IsToBeAutomated field to given value.
 

--- a/qase-api-client/docs/TestCaseCreate.md
+++ b/qase-api-client/docs/TestCaseCreate.md
@@ -17,8 +17,8 @@ Name | Type | Description | Notes
 **SuiteId** | Pointer to **int64** |  | [optional] 
 **MilestoneId** | Pointer to **int64** |  | [optional] 
 **Automation** | Pointer to **int32** | Deprecated, use &#x60;isManual&#x60; and &#x60;isToBeAutomated&#x60; instead. Encodes the test case automation state as a single integer: &#x60;0&#x60; &#x3D; manual, &#x60;1&#x60; &#x3D; manual planned to be automated, &#x60;2&#x60; &#x3D; automated. If both &#x60;automation&#x60; and &#x60;isManual&#x60;/&#x60;isToBeAutomated&#x60; are provided, &#x60;isManual&#x60; and &#x60;isToBeAutomated&#x60; take precedence. | [optional] 
-**IsManual** | Pointer to **int32** | &#x60;1&#x60; if the case is manual, &#x60;0&#x60; if it is automated. Combined with &#x60;isToBeAutomated&#x60;, replaces the deprecated &#x60;automation&#x60; field. | [optional] 
-**IsToBeAutomated** | Pointer to **int32** | &#x60;1&#x60; if a manual case is planned to be automated, &#x60;0&#x60; otherwise. Only meaningful when &#x60;isManual &#x3D; 1&#x60;; ignored when &#x60;isManual &#x3D; 0&#x60;. | [optional] 
+**IsManual** | Pointer to **bool** | &#x60;true&#x60; if the case is manual, &#x60;false&#x60; if it is automated. Combined with &#x60;isToBeAutomated&#x60;, replaces the deprecated &#x60;automation&#x60; field. | [optional] 
+**IsToBeAutomated** | Pointer to **bool** | &#x60;true&#x60; if a manual case is planned to be automated, &#x60;false&#x60; otherwise. Only meaningful when &#x60;isManual&#x60; is &#x60;true&#x60;; ignored when &#x60;isManual&#x60; is &#x60;false&#x60;. | [optional] 
 **Status** | Pointer to **int32** |  | [optional] 
 **StepsType** | Pointer to **string** | Determines the format of the steps field. When \&quot;classic\&quot;, steps use the standard action/expected_result/data format. When \&quot;gherkin\&quot;, steps use the {value: \&quot;Given...\\nWhen...\\nThen...\&quot;} format. | [optional] [default to "classic"]
 **Attachments** | Pointer to **[]string** | A list of Attachment hashes. | [optional] 
@@ -371,20 +371,20 @@ HasAutomation returns a boolean if a field has been set.
 
 ### GetIsManual
 
-`func (o *TestCaseCreate) GetIsManual() int32`
+`func (o *TestCaseCreate) GetIsManual() bool`
 
 GetIsManual returns the IsManual field if non-nil, zero value otherwise.
 
 ### GetIsManualOk
 
-`func (o *TestCaseCreate) GetIsManualOk() (*int32, bool)`
+`func (o *TestCaseCreate) GetIsManualOk() (*bool, bool)`
 
 GetIsManualOk returns a tuple with the IsManual field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetIsManual
 
-`func (o *TestCaseCreate) SetIsManual(v int32)`
+`func (o *TestCaseCreate) SetIsManual(v bool)`
 
 SetIsManual sets IsManual field to given value.
 
@@ -396,20 +396,20 @@ HasIsManual returns a boolean if a field has been set.
 
 ### GetIsToBeAutomated
 
-`func (o *TestCaseCreate) GetIsToBeAutomated() int32`
+`func (o *TestCaseCreate) GetIsToBeAutomated() bool`
 
 GetIsToBeAutomated returns the IsToBeAutomated field if non-nil, zero value otherwise.
 
 ### GetIsToBeAutomatedOk
 
-`func (o *TestCaseCreate) GetIsToBeAutomatedOk() (*int32, bool)`
+`func (o *TestCaseCreate) GetIsToBeAutomatedOk() (*bool, bool)`
 
 GetIsToBeAutomatedOk returns a tuple with the IsToBeAutomated field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetIsToBeAutomated
 
-`func (o *TestCaseCreate) SetIsToBeAutomated(v int32)`
+`func (o *TestCaseCreate) SetIsToBeAutomated(v bool)`
 
 SetIsToBeAutomated sets IsToBeAutomated field to given value.
 

--- a/qase-api-client/docs/TestCaseUpdate.md
+++ b/qase-api-client/docs/TestCaseUpdate.md
@@ -17,8 +17,8 @@ Name | Type | Description | Notes
 **SuiteId** | Pointer to **int64** |  | [optional] 
 **MilestoneId** | Pointer to **int64** |  | [optional] 
 **Automation** | Pointer to **int32** | Deprecated, use &#x60;isManual&#x60; and &#x60;isToBeAutomated&#x60; instead. Encodes the test case automation state as a single integer: &#x60;0&#x60; &#x3D; manual, &#x60;1&#x60; &#x3D; manual planned to be automated, &#x60;2&#x60; &#x3D; automated. If both &#x60;automation&#x60; and &#x60;isManual&#x60;/&#x60;isToBeAutomated&#x60; are provided, &#x60;isManual&#x60; and &#x60;isToBeAutomated&#x60; take precedence. | [optional] 
-**IsManual** | Pointer to **int32** | &#x60;1&#x60; if the case is manual, &#x60;0&#x60; if it is automated. Combined with &#x60;isToBeAutomated&#x60;, replaces the deprecated &#x60;automation&#x60; field. | [optional] 
-**IsToBeAutomated** | Pointer to **int32** | &#x60;1&#x60; if a manual case is planned to be automated, &#x60;0&#x60; otherwise. Only meaningful when &#x60;isManual &#x3D; 1&#x60;; ignored when &#x60;isManual &#x3D; 0&#x60;. | [optional] 
+**IsManual** | Pointer to **bool** | &#x60;true&#x60; if the case is manual, &#x60;false&#x60; if it is automated. Combined with &#x60;isToBeAutomated&#x60;, replaces the deprecated &#x60;automation&#x60; field. | [optional] 
+**IsToBeAutomated** | Pointer to **bool** | &#x60;true&#x60; if a manual case is planned to be automated, &#x60;false&#x60; otherwise. Only meaningful when &#x60;isManual&#x60; is &#x60;true&#x60;; ignored when &#x60;isManual&#x60; is &#x60;false&#x60;. | [optional] 
 **Status** | Pointer to **int32** |  | [optional] 
 **StepsType** | Pointer to **string** | Determines the format of the steps field. When \&quot;classic\&quot;, steps use the standard action/expected_result/data format. When \&quot;gherkin\&quot;, steps use the {value: \&quot;Given...\\nWhen...\\nThen...\&quot;} format. | [optional] [default to "classic"]
 **Attachments** | Pointer to **[]string** | A list of Attachment hashes. | [optional] 
@@ -374,20 +374,20 @@ HasAutomation returns a boolean if a field has been set.
 
 ### GetIsManual
 
-`func (o *TestCaseUpdate) GetIsManual() int32`
+`func (o *TestCaseUpdate) GetIsManual() bool`
 
 GetIsManual returns the IsManual field if non-nil, zero value otherwise.
 
 ### GetIsManualOk
 
-`func (o *TestCaseUpdate) GetIsManualOk() (*int32, bool)`
+`func (o *TestCaseUpdate) GetIsManualOk() (*bool, bool)`
 
 GetIsManualOk returns a tuple with the IsManual field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetIsManual
 
-`func (o *TestCaseUpdate) SetIsManual(v int32)`
+`func (o *TestCaseUpdate) SetIsManual(v bool)`
 
 SetIsManual sets IsManual field to given value.
 
@@ -399,20 +399,20 @@ HasIsManual returns a boolean if a field has been set.
 
 ### GetIsToBeAutomated
 
-`func (o *TestCaseUpdate) GetIsToBeAutomated() int32`
+`func (o *TestCaseUpdate) GetIsToBeAutomated() bool`
 
 GetIsToBeAutomated returns the IsToBeAutomated field if non-nil, zero value otherwise.
 
 ### GetIsToBeAutomatedOk
 
-`func (o *TestCaseUpdate) GetIsToBeAutomatedOk() (*int32, bool)`
+`func (o *TestCaseUpdate) GetIsToBeAutomatedOk() (*bool, bool)`
 
 GetIsToBeAutomatedOk returns a tuple with the IsToBeAutomated field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetIsToBeAutomated
 
-`func (o *TestCaseUpdate) SetIsToBeAutomated(v int32)`
+`func (o *TestCaseUpdate) SetIsToBeAutomated(v bool)`
 
 SetIsToBeAutomated sets IsToBeAutomated field to given value.
 

--- a/qase-api-client/docs/TestCasebulkCasesInner.md
+++ b/qase-api-client/docs/TestCasebulkCasesInner.md
@@ -17,8 +17,8 @@ Name | Type | Description | Notes
 **SuiteId** | Pointer to **int64** |  | [optional] 
 **MilestoneId** | Pointer to **int64** |  | [optional] 
 **Automation** | Pointer to **int32** | Deprecated, use &#x60;isManual&#x60; and &#x60;isToBeAutomated&#x60; instead. Encodes the test case automation state as a single integer: &#x60;0&#x60; &#x3D; manual, &#x60;1&#x60; &#x3D; manual planned to be automated, &#x60;2&#x60; &#x3D; automated. If both &#x60;automation&#x60; and &#x60;isManual&#x60;/&#x60;isToBeAutomated&#x60; are provided, &#x60;isManual&#x60; and &#x60;isToBeAutomated&#x60; take precedence. | [optional] 
-**IsManual** | Pointer to **int32** | &#x60;1&#x60; if the case is manual, &#x60;0&#x60; if it is automated. Combined with &#x60;isToBeAutomated&#x60;, replaces the deprecated &#x60;automation&#x60; field. | [optional] 
-**IsToBeAutomated** | Pointer to **int32** | &#x60;1&#x60; if a manual case is planned to be automated, &#x60;0&#x60; otherwise. Only meaningful when &#x60;isManual &#x3D; 1&#x60;; ignored when &#x60;isManual &#x3D; 0&#x60;. | [optional] 
+**IsManual** | Pointer to **bool** | &#x60;true&#x60; if the case is manual, &#x60;false&#x60; if it is automated. Combined with &#x60;isToBeAutomated&#x60;, replaces the deprecated &#x60;automation&#x60; field. | [optional] 
+**IsToBeAutomated** | Pointer to **bool** | &#x60;true&#x60; if a manual case is planned to be automated, &#x60;false&#x60; otherwise. Only meaningful when &#x60;isManual&#x60; is &#x60;true&#x60;; ignored when &#x60;isManual&#x60; is &#x60;false&#x60;. | [optional] 
 **Status** | Pointer to **int32** |  | [optional] 
 **StepsType** | Pointer to **string** | Determines the format of the steps field. When \&quot;classic\&quot;, steps use the standard action/expected_result/data format. When \&quot;gherkin\&quot;, steps use the {value: \&quot;Given...\\nWhen...\\nThen...\&quot;} format. | [optional] [default to "classic"]
 **Attachments** | Pointer to **[]string** | A list of Attachment hashes. | [optional] 
@@ -372,20 +372,20 @@ HasAutomation returns a boolean if a field has been set.
 
 ### GetIsManual
 
-`func (o *TestCasebulkCasesInner) GetIsManual() int32`
+`func (o *TestCasebulkCasesInner) GetIsManual() bool`
 
 GetIsManual returns the IsManual field if non-nil, zero value otherwise.
 
 ### GetIsManualOk
 
-`func (o *TestCasebulkCasesInner) GetIsManualOk() (*int32, bool)`
+`func (o *TestCasebulkCasesInner) GetIsManualOk() (*bool, bool)`
 
 GetIsManualOk returns a tuple with the IsManual field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetIsManual
 
-`func (o *TestCasebulkCasesInner) SetIsManual(v int32)`
+`func (o *TestCasebulkCasesInner) SetIsManual(v bool)`
 
 SetIsManual sets IsManual field to given value.
 
@@ -397,20 +397,20 @@ HasIsManual returns a boolean if a field has been set.
 
 ### GetIsToBeAutomated
 
-`func (o *TestCasebulkCasesInner) GetIsToBeAutomated() int32`
+`func (o *TestCasebulkCasesInner) GetIsToBeAutomated() bool`
 
 GetIsToBeAutomated returns the IsToBeAutomated field if non-nil, zero value otherwise.
 
 ### GetIsToBeAutomatedOk
 
-`func (o *TestCasebulkCasesInner) GetIsToBeAutomatedOk() (*int32, bool)`
+`func (o *TestCasebulkCasesInner) GetIsToBeAutomatedOk() (*bool, bool)`
 
 GetIsToBeAutomatedOk returns a tuple with the IsToBeAutomated field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetIsToBeAutomated
 
-`func (o *TestCasebulkCasesInner) SetIsToBeAutomated(v int32)`
+`func (o *TestCasebulkCasesInner) SetIsToBeAutomated(v bool)`
 
 SetIsToBeAutomated sets IsToBeAutomated field to given value.
 

--- a/qase-api-client/model_test_case.go
+++ b/qase-api-client/model_test_case.go
@@ -36,10 +36,10 @@ type TestCase struct {
 	// Deprecated, use `isManual` and `isToBeAutomated` instead. Encodes the test case automation state as a single integer: `0` = manual, `1` = manual planned to be automated, `2` = automated.
 	// Deprecated
 	Automation *int32 `json:"automation,omitempty"`
-	// `1` if the case is manual, `0` if it is automated. Combined with `isToBeAutomated`, replaces the deprecated `automation` field.
-	IsManual *int32 `json:"isManual,omitempty"`
-	// `1` if a manual case is planned to be automated, `0` otherwise. Only meaningful when `isManual = 1`; ignored when `isManual = 0`.
-	IsToBeAutomated *int32             `json:"isToBeAutomated,omitempty"`
+	// `true` if the case is manual, `false` if it is automated. Combined with `isToBeAutomated`, replaces the deprecated `automation` field.
+	IsManual *bool `json:"isManual,omitempty"`
+	// `true` if a manual case is planned to be automated, `false` otherwise. Only meaningful when `isManual` is `true`; ignored when `isManual` is `false`.
+	IsToBeAutomated *bool              `json:"isToBeAutomated,omitempty"`
 	Status          *int32             `json:"status,omitempty"`
 	MilestoneId     NullableInt64      `json:"milestone_id,omitempty"`
 	SuiteId         NullableInt64      `json:"suite_id,omitempty"`
@@ -538,9 +538,9 @@ func (o *TestCase) SetAutomation(v int32) {
 }
 
 // GetIsManual returns the IsManual field value if set, zero value otherwise.
-func (o *TestCase) GetIsManual() int32 {
+func (o *TestCase) GetIsManual() bool {
 	if o == nil || IsNil(o.IsManual) {
-		var ret int32
+		var ret bool
 		return ret
 	}
 	return *o.IsManual
@@ -548,7 +548,7 @@ func (o *TestCase) GetIsManual() int32 {
 
 // GetIsManualOk returns a tuple with the IsManual field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *TestCase) GetIsManualOk() (*int32, bool) {
+func (o *TestCase) GetIsManualOk() (*bool, bool) {
 	if o == nil || IsNil(o.IsManual) {
 		return nil, false
 	}
@@ -564,15 +564,15 @@ func (o *TestCase) HasIsManual() bool {
 	return false
 }
 
-// SetIsManual gets a reference to the given int32 and assigns it to the IsManual field.
-func (o *TestCase) SetIsManual(v int32) {
+// SetIsManual gets a reference to the given bool and assigns it to the IsManual field.
+func (o *TestCase) SetIsManual(v bool) {
 	o.IsManual = &v
 }
 
 // GetIsToBeAutomated returns the IsToBeAutomated field value if set, zero value otherwise.
-func (o *TestCase) GetIsToBeAutomated() int32 {
+func (o *TestCase) GetIsToBeAutomated() bool {
 	if o == nil || IsNil(o.IsToBeAutomated) {
-		var ret int32
+		var ret bool
 		return ret
 	}
 	return *o.IsToBeAutomated
@@ -580,7 +580,7 @@ func (o *TestCase) GetIsToBeAutomated() int32 {
 
 // GetIsToBeAutomatedOk returns a tuple with the IsToBeAutomated field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *TestCase) GetIsToBeAutomatedOk() (*int32, bool) {
+func (o *TestCase) GetIsToBeAutomatedOk() (*bool, bool) {
 	if o == nil || IsNil(o.IsToBeAutomated) {
 		return nil, false
 	}
@@ -596,8 +596,8 @@ func (o *TestCase) HasIsToBeAutomated() bool {
 	return false
 }
 
-// SetIsToBeAutomated gets a reference to the given int32 and assigns it to the IsToBeAutomated field.
-func (o *TestCase) SetIsToBeAutomated(v int32) {
+// SetIsToBeAutomated gets a reference to the given bool and assigns it to the IsToBeAutomated field.
+func (o *TestCase) SetIsToBeAutomated(v bool) {
 	o.IsToBeAutomated = &v
 }
 

--- a/qase-api-client/model_test_case_create.go
+++ b/qase-api-client/model_test_case_create.go
@@ -37,10 +37,10 @@ type TestCaseCreate struct {
 	// Deprecated, use `isManual` and `isToBeAutomated` instead. Encodes the test case automation state as a single integer: `0` = manual, `1` = manual planned to be automated, `2` = automated. If both `automation` and `isManual`/`isToBeAutomated` are provided, `isManual` and `isToBeAutomated` take precedence.
 	// Deprecated
 	Automation *int32 `json:"automation,omitempty"`
-	// `1` if the case is manual, `0` if it is automated. Combined with `isToBeAutomated`, replaces the deprecated `automation` field.
-	IsManual *int32 `json:"isManual,omitempty"`
-	// `1` if a manual case is planned to be automated, `0` otherwise. Only meaningful when `isManual = 1`; ignored when `isManual = 0`.
-	IsToBeAutomated *int32 `json:"isToBeAutomated,omitempty"`
+	// `true` if the case is manual, `false` if it is automated. Combined with `isToBeAutomated`, replaces the deprecated `automation` field.
+	IsManual *bool `json:"isManual,omitempty"`
+	// `true` if a manual case is planned to be automated, `false` otherwise. Only meaningful when `isManual` is `true`; ignored when `isManual` is `false`.
+	IsToBeAutomated *bool  `json:"isToBeAutomated,omitempty"`
 	Status          *int32 `json:"status,omitempty"`
 	// Determines the format of the steps field. When \"classic\", steps use the standard action/expected_result/data format. When \"gherkin\", steps use the {value: \"Given...\\nWhen...\\nThen...\"} format.
 	StepsType *string `json:"steps_type,omitempty"`
@@ -494,9 +494,9 @@ func (o *TestCaseCreate) SetAutomation(v int32) {
 }
 
 // GetIsManual returns the IsManual field value if set, zero value otherwise.
-func (o *TestCaseCreate) GetIsManual() int32 {
+func (o *TestCaseCreate) GetIsManual() bool {
 	if o == nil || IsNil(o.IsManual) {
-		var ret int32
+		var ret bool
 		return ret
 	}
 	return *o.IsManual
@@ -504,7 +504,7 @@ func (o *TestCaseCreate) GetIsManual() int32 {
 
 // GetIsManualOk returns a tuple with the IsManual field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *TestCaseCreate) GetIsManualOk() (*int32, bool) {
+func (o *TestCaseCreate) GetIsManualOk() (*bool, bool) {
 	if o == nil || IsNil(o.IsManual) {
 		return nil, false
 	}
@@ -520,15 +520,15 @@ func (o *TestCaseCreate) HasIsManual() bool {
 	return false
 }
 
-// SetIsManual gets a reference to the given int32 and assigns it to the IsManual field.
-func (o *TestCaseCreate) SetIsManual(v int32) {
+// SetIsManual gets a reference to the given bool and assigns it to the IsManual field.
+func (o *TestCaseCreate) SetIsManual(v bool) {
 	o.IsManual = &v
 }
 
 // GetIsToBeAutomated returns the IsToBeAutomated field value if set, zero value otherwise.
-func (o *TestCaseCreate) GetIsToBeAutomated() int32 {
+func (o *TestCaseCreate) GetIsToBeAutomated() bool {
 	if o == nil || IsNil(o.IsToBeAutomated) {
-		var ret int32
+		var ret bool
 		return ret
 	}
 	return *o.IsToBeAutomated
@@ -536,7 +536,7 @@ func (o *TestCaseCreate) GetIsToBeAutomated() int32 {
 
 // GetIsToBeAutomatedOk returns a tuple with the IsToBeAutomated field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *TestCaseCreate) GetIsToBeAutomatedOk() (*int32, bool) {
+func (o *TestCaseCreate) GetIsToBeAutomatedOk() (*bool, bool) {
 	if o == nil || IsNil(o.IsToBeAutomated) {
 		return nil, false
 	}
@@ -552,8 +552,8 @@ func (o *TestCaseCreate) HasIsToBeAutomated() bool {
 	return false
 }
 
-// SetIsToBeAutomated gets a reference to the given int32 and assigns it to the IsToBeAutomated field.
-func (o *TestCaseCreate) SetIsToBeAutomated(v int32) {
+// SetIsToBeAutomated gets a reference to the given bool and assigns it to the IsToBeAutomated field.
+func (o *TestCaseCreate) SetIsToBeAutomated(v bool) {
 	o.IsToBeAutomated = &v
 }
 

--- a/qase-api-client/model_test_case_update.go
+++ b/qase-api-client/model_test_case_update.go
@@ -35,10 +35,10 @@ type TestCaseUpdate struct {
 	// Deprecated, use `isManual` and `isToBeAutomated` instead. Encodes the test case automation state as a single integer: `0` = manual, `1` = manual planned to be automated, `2` = automated. If both `automation` and `isManual`/`isToBeAutomated` are provided, `isManual` and `isToBeAutomated` take precedence.
 	// Deprecated
 	Automation *int32 `json:"automation,omitempty"`
-	// `1` if the case is manual, `0` if it is automated. Combined with `isToBeAutomated`, replaces the deprecated `automation` field.
-	IsManual *int32 `json:"isManual,omitempty"`
-	// `1` if a manual case is planned to be automated, `0` otherwise. Only meaningful when `isManual = 1`; ignored when `isManual = 0`.
-	IsToBeAutomated *int32 `json:"isToBeAutomated,omitempty"`
+	// `true` if the case is manual, `false` if it is automated. Combined with `isToBeAutomated`, replaces the deprecated `automation` field.
+	IsManual *bool `json:"isManual,omitempty"`
+	// `true` if a manual case is planned to be automated, `false` otherwise. Only meaningful when `isManual` is `true`; ignored when `isManual` is `false`.
+	IsToBeAutomated *bool  `json:"isToBeAutomated,omitempty"`
 	Status          *int32 `json:"status,omitempty"`
 	// Determines the format of the steps field. When \"classic\", steps use the standard action/expected_result/data format. When \"gherkin\", steps use the {value: \"Given...\\nWhen...\\nThen...\"} format.
 	StepsType *string `json:"steps_type,omitempty"`
@@ -495,9 +495,9 @@ func (o *TestCaseUpdate) SetAutomation(v int32) {
 }
 
 // GetIsManual returns the IsManual field value if set, zero value otherwise.
-func (o *TestCaseUpdate) GetIsManual() int32 {
+func (o *TestCaseUpdate) GetIsManual() bool {
 	if o == nil || IsNil(o.IsManual) {
-		var ret int32
+		var ret bool
 		return ret
 	}
 	return *o.IsManual
@@ -505,7 +505,7 @@ func (o *TestCaseUpdate) GetIsManual() int32 {
 
 // GetIsManualOk returns a tuple with the IsManual field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *TestCaseUpdate) GetIsManualOk() (*int32, bool) {
+func (o *TestCaseUpdate) GetIsManualOk() (*bool, bool) {
 	if o == nil || IsNil(o.IsManual) {
 		return nil, false
 	}
@@ -521,15 +521,15 @@ func (o *TestCaseUpdate) HasIsManual() bool {
 	return false
 }
 
-// SetIsManual gets a reference to the given int32 and assigns it to the IsManual field.
-func (o *TestCaseUpdate) SetIsManual(v int32) {
+// SetIsManual gets a reference to the given bool and assigns it to the IsManual field.
+func (o *TestCaseUpdate) SetIsManual(v bool) {
 	o.IsManual = &v
 }
 
 // GetIsToBeAutomated returns the IsToBeAutomated field value if set, zero value otherwise.
-func (o *TestCaseUpdate) GetIsToBeAutomated() int32 {
+func (o *TestCaseUpdate) GetIsToBeAutomated() bool {
 	if o == nil || IsNil(o.IsToBeAutomated) {
-		var ret int32
+		var ret bool
 		return ret
 	}
 	return *o.IsToBeAutomated
@@ -537,7 +537,7 @@ func (o *TestCaseUpdate) GetIsToBeAutomated() int32 {
 
 // GetIsToBeAutomatedOk returns a tuple with the IsToBeAutomated field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *TestCaseUpdate) GetIsToBeAutomatedOk() (*int32, bool) {
+func (o *TestCaseUpdate) GetIsToBeAutomatedOk() (*bool, bool) {
 	if o == nil || IsNil(o.IsToBeAutomated) {
 		return nil, false
 	}
@@ -553,8 +553,8 @@ func (o *TestCaseUpdate) HasIsToBeAutomated() bool {
 	return false
 }
 
-// SetIsToBeAutomated gets a reference to the given int32 and assigns it to the IsToBeAutomated field.
-func (o *TestCaseUpdate) SetIsToBeAutomated(v int32) {
+// SetIsToBeAutomated gets a reference to the given bool and assigns it to the IsToBeAutomated field.
+func (o *TestCaseUpdate) SetIsToBeAutomated(v bool) {
 	o.IsToBeAutomated = &v
 }
 

--- a/qase-api-client/model_test_casebulk_cases_inner.go
+++ b/qase-api-client/model_test_casebulk_cases_inner.go
@@ -37,10 +37,10 @@ type TestCasebulkCasesInner struct {
 	// Deprecated, use `isManual` and `isToBeAutomated` instead. Encodes the test case automation state as a single integer: `0` = manual, `1` = manual planned to be automated, `2` = automated. If both `automation` and `isManual`/`isToBeAutomated` are provided, `isManual` and `isToBeAutomated` take precedence.
 	// Deprecated
 	Automation *int32 `json:"automation,omitempty"`
-	// `1` if the case is manual, `0` if it is automated. Combined with `isToBeAutomated`, replaces the deprecated `automation` field.
-	IsManual *int32 `json:"isManual,omitempty"`
-	// `1` if a manual case is planned to be automated, `0` otherwise. Only meaningful when `isManual = 1`; ignored when `isManual = 0`.
-	IsToBeAutomated *int32 `json:"isToBeAutomated,omitempty"`
+	// `true` if the case is manual, `false` if it is automated. Combined with `isToBeAutomated`, replaces the deprecated `automation` field.
+	IsManual *bool `json:"isManual,omitempty"`
+	// `true` if a manual case is planned to be automated, `false` otherwise. Only meaningful when `isManual` is `true`; ignored when `isManual` is `false`.
+	IsToBeAutomated *bool  `json:"isToBeAutomated,omitempty"`
 	Status          *int32 `json:"status,omitempty"`
 	// Determines the format of the steps field. When \"classic\", steps use the standard action/expected_result/data format. When \"gherkin\", steps use the {value: \"Given...\\nWhen...\\nThen...\"} format.
 	StepsType *string `json:"steps_type,omitempty"`
@@ -495,9 +495,9 @@ func (o *TestCasebulkCasesInner) SetAutomation(v int32) {
 }
 
 // GetIsManual returns the IsManual field value if set, zero value otherwise.
-func (o *TestCasebulkCasesInner) GetIsManual() int32 {
+func (o *TestCasebulkCasesInner) GetIsManual() bool {
 	if o == nil || IsNil(o.IsManual) {
-		var ret int32
+		var ret bool
 		return ret
 	}
 	return *o.IsManual
@@ -505,7 +505,7 @@ func (o *TestCasebulkCasesInner) GetIsManual() int32 {
 
 // GetIsManualOk returns a tuple with the IsManual field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *TestCasebulkCasesInner) GetIsManualOk() (*int32, bool) {
+func (o *TestCasebulkCasesInner) GetIsManualOk() (*bool, bool) {
 	if o == nil || IsNil(o.IsManual) {
 		return nil, false
 	}
@@ -521,15 +521,15 @@ func (o *TestCasebulkCasesInner) HasIsManual() bool {
 	return false
 }
 
-// SetIsManual gets a reference to the given int32 and assigns it to the IsManual field.
-func (o *TestCasebulkCasesInner) SetIsManual(v int32) {
+// SetIsManual gets a reference to the given bool and assigns it to the IsManual field.
+func (o *TestCasebulkCasesInner) SetIsManual(v bool) {
 	o.IsManual = &v
 }
 
 // GetIsToBeAutomated returns the IsToBeAutomated field value if set, zero value otherwise.
-func (o *TestCasebulkCasesInner) GetIsToBeAutomated() int32 {
+func (o *TestCasebulkCasesInner) GetIsToBeAutomated() bool {
 	if o == nil || IsNil(o.IsToBeAutomated) {
-		var ret int32
+		var ret bool
 		return ret
 	}
 	return *o.IsToBeAutomated
@@ -537,7 +537,7 @@ func (o *TestCasebulkCasesInner) GetIsToBeAutomated() int32 {
 
 // GetIsToBeAutomatedOk returns a tuple with the IsToBeAutomated field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *TestCasebulkCasesInner) GetIsToBeAutomatedOk() (*int32, bool) {
+func (o *TestCasebulkCasesInner) GetIsToBeAutomatedOk() (*bool, bool) {
 	if o == nil || IsNil(o.IsToBeAutomated) {
 		return nil, false
 	}
@@ -553,8 +553,8 @@ func (o *TestCasebulkCasesInner) HasIsToBeAutomated() bool {
 	return false
 }
 
-// SetIsToBeAutomated gets a reference to the given int32 and assigns it to the IsToBeAutomated field.
-func (o *TestCasebulkCasesInner) SetIsToBeAutomated(v int32) {
+// SetIsToBeAutomated gets a reference to the given bool and assigns it to the IsToBeAutomated field.
+func (o *TestCasebulkCasesInner) SetIsToBeAutomated(v bool) {
 	o.IsToBeAutomated = &v
 }
 


### PR DESCRIPTION
## Summary

- Updated API clients to the latest OpenAPI specification

### Targets updated:
- v1 (`qase-api-client`): no version file (Go module, versioned via git tag)

### Change
`IsManual` and `IsToBeAutomated` on `TestCase` / `TestCaseCreate` / `TestCaseUpdate` are now typed as `*bool` (was `*int32`), matching the actual API response (JSON booleans).

### Protected files (skipped):
- `configuration.go`, `client.go`, `model_configuration.go`, `model_configuration_group.go`, `model_search_response_all_of_result_entities.go`

### Warnings:
None