### PR TITLE
chore: update API clients to latest specification

### DIFF
--- a/qase-api-client/api_cases.go
+++ b/qase-api-client/api_cases.go
@@ -876,25 +876,25 @@ func (r ApiGetCasesRequest) Priority(priority string) ApiGetCasesRequest {
 	return r
 }
 
-// A list of type values separated by comma. Possible values: other, functional smoke, regression, security, usability, performance, acceptance
+// A list of type values separated by comma. Possible values: other, functional, smoke, regression, security, usability, performance, acceptance
 func (r ApiGetCasesRequest) Type_(type_ string) ApiGetCasesRequest {
 	r.type_ = &type_
 	return r
 }
 
-// A list of behavior values separated by comma. Possible values: undefined, positive negative, destructive
+// A list of behavior values separated by comma. Possible values: undefined, positive, negative, destructive
 func (r ApiGetCasesRequest) Behavior(behavior string) ApiGetCasesRequest {
 	r.behavior = &behavior
 	return r
 }
 
-// A list of values separated by comma. Possible values: is-not-automated, automated to-be-automated
+// A list of values separated by comma. Possible values: is-not-automated, automated, to-be-automated
 func (r ApiGetCasesRequest) Automation(automation string) ApiGetCasesRequest {
 	r.automation = &automation
 	return r
 }
 
-// A list of values separated by comma. Possible values: actual, draft deprecated
+// A list of values separated by comma. Possible values: actual, draft, deprecated
 func (r ApiGetCasesRequest) Status(status string) ApiGetCasesRequest {
 	r.status = &status
 	return r

--- a/qase-api-client/docs/CasesAPI.md
+++ b/qase-api-client/docs/CasesAPI.md
@@ -474,10 +474,10 @@ func main() {
 	suiteId := int32(56) // int32 | ID of test suite. (optional)
 	severity := "severity_example" // string | A list of severity values separated by comma. Possible values: undefined, blocker, critical, major, normal, minor, trivial  (optional)
 	priority := "priority_example" // string | A list of priority values separated by comma. Possible values: undefined, high, medium, low  (optional)
-	type_ := "type__example" // string | A list of type values separated by comma. Possible values: other, functional smoke, regression, security, usability, performance, acceptance  (optional)
-	behavior := "behavior_example" // string | A list of behavior values separated by comma. Possible values: undefined, positive negative, destructive  (optional)
-	automation := "automation_example" // string | A list of values separated by comma. Possible values: is-not-automated, automated to-be-automated  (optional)
-	status := "status_example" // string | A list of values separated by comma. Possible values: actual, draft deprecated  (optional)
+	type_ := "type__example" // string | A list of type values separated by comma. Possible values: other, functional, smoke, regression, security, usability, performance, acceptance  (optional)
+	behavior := "behavior_example" // string | A list of behavior values separated by comma. Possible values: undefined, positive, negative, destructive  (optional)
+	automation := "automation_example" // string | A list of values separated by comma. Possible values: is-not-automated, automated, to-be-automated  (optional)
+	status := "status_example" // string | A list of values separated by comma. Possible values: actual, draft, deprecated  (optional)
 	externalIssuesType := "externalIssuesType_example" // string | An integration type.  (optional)
 	externalIssuesIds := []string{"Inner_example"} // []string | A list of issue IDs. (optional)
 	include := "include_example" // string | A list of entities to include in response separated by comma. Possible values: external_issues.  (optional)
@@ -517,10 +517,10 @@ Name | Type | Description  | Notes
  **suiteId** | **int32** | ID of test suite. | 
  **severity** | **string** | A list of severity values separated by comma. Possible values: undefined, blocker, critical, major, normal, minor, trivial  | 
  **priority** | **string** | A list of priority values separated by comma. Possible values: undefined, high, medium, low  | 
- **type_** | **string** | A list of type values separated by comma. Possible values: other, functional smoke, regression, security, usability, performance, acceptance  | 
- **behavior** | **string** | A list of behavior values separated by comma. Possible values: undefined, positive negative, destructive  | 
- **automation** | **string** | A list of values separated by comma. Possible values: is-not-automated, automated to-be-automated  | 
- **status** | **string** | A list of values separated by comma. Possible values: actual, draft deprecated  | 
+ **type_** | **string** | A list of type values separated by comma. Possible values: other, functional, smoke, regression, security, usability, performance, acceptance  | 
+ **behavior** | **string** | A list of behavior values separated by comma. Possible values: undefined, positive, negative, destructive  | 
+ **automation** | **string** | A list of values separated by comma. Possible values: is-not-automated, automated, to-be-automated  | 
+ **status** | **string** | A list of values separated by comma. Possible values: actual, draft, deprecated  | 
  **externalIssuesType** | **string** | An integration type.  | 
  **externalIssuesIds** | **[]string** | A list of issue IDs. | 
  **include** | **string** | A list of entities to include in response separated by comma. Possible values: external_issues.  | 

--- a/qase-api-client/docs/TestStepCreate.md
+++ b/qase-api-client/docs/TestStepCreate.md
@@ -5,6 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Action** | Pointer to **string** | Step action text. Used for classic steps. For gherkin steps, use the \&quot;value\&quot; property instead. | [optional] 
+**Shared** | Pointer to **string** | Hash of an existing shared step to insert at this position. | [optional] 
 **ExpectedResult** | Pointer to **string** |  | [optional] 
 **Data** | Pointer to **string** |  | [optional] 
 **Value** | Pointer to **string** | Gherkin scenario text. Used when steps_type is \&quot;gherkin\&quot;. Example: \&quot;Given a user exists\\nWhen they log in\\nThen they see the dashboard\&quot; | [optional] 
@@ -55,6 +56,31 @@ SetAction sets Action field to given value.
 `func (o *TestStepCreate) HasAction() bool`
 
 HasAction returns a boolean if a field has been set.
+
+### GetShared
+
+`func (o *TestStepCreate) GetShared() string`
+
+GetShared returns the Shared field if non-nil, zero value otherwise.
+
+### GetSharedOk
+
+`func (o *TestStepCreate) GetSharedOk() (*string, bool)`
+
+GetSharedOk returns a tuple with the Shared field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetShared
+
+`func (o *TestStepCreate) SetShared(v string)`
+
+SetShared sets Shared field to given value.
+
+### HasShared
+
+`func (o *TestStepCreate) HasShared() bool`
+
+HasShared returns a boolean if a field has been set.
 
 ### GetExpectedResult
 

--- a/qase-api-client/model_test_step_create.go
+++ b/qase-api-client/model_test_step_create.go
@@ -21,7 +21,9 @@ var _ MappedNullable = &TestStepCreate{}
 // TestStepCreate struct for TestStepCreate
 type TestStepCreate struct {
 	// Step action text. Used for classic steps. For gherkin steps, use the \"value\" property instead.
-	Action         *string `json:"action,omitempty"`
+	Action *string `json:"action,omitempty"`
+	// Hash of an existing shared step to insert at this position.
+	Shared         *string `json:"shared,omitempty"`
 	ExpectedResult *string `json:"expected_result,omitempty"`
 	Data           *string `json:"data,omitempty"`
 	// Gherkin scenario text. Used when steps_type is \"gherkin\". Example: \"Given a user exists\\nWhen they log in\\nThen they see the dashboard\"
@@ -81,6 +83,38 @@ func (o *TestStepCreate) HasAction() bool {
 // SetAction gets a reference to the given string and assigns it to the Action field.
 func (o *TestStepCreate) SetAction(v string) {
 	o.Action = &v
+}
+
+// GetShared returns the Shared field value if set, zero value otherwise.
+func (o *TestStepCreate) GetShared() string {
+	if o == nil || IsNil(o.Shared) {
+		var ret string
+		return ret
+	}
+	return *o.Shared
+}
+
+// GetSharedOk returns a tuple with the Shared field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TestStepCreate) GetSharedOk() (*string, bool) {
+	if o == nil || IsNil(o.Shared) {
+		return nil, false
+	}
+	return o.Shared, true
+}
+
+// HasShared returns a boolean if a field has been set.
+func (o *TestStepCreate) HasShared() bool {
+	if o != nil && !IsNil(o.Shared) {
+		return true
+	}
+
+	return false
+}
+
+// SetShared gets a reference to the given string and assigns it to the Shared field.
+func (o *TestStepCreate) SetShared(v string) {
+	o.Shared = &v
 }
 
 // GetExpectedResult returns the ExpectedResult field value if set, zero value otherwise.
@@ -290,6 +324,9 @@ func (o TestStepCreate) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Action) {
 		toSerialize["action"] = o.Action
+	}
+	if !IsNil(o.Shared) {
+		toSerialize["shared"] = o.Shared
 	}
 	if !IsNil(o.ExpectedResult) {
 		toSerialize["expected_result"] = o.ExpectedResult


### PR DESCRIPTION
Regenerated the v1 API client from the latest OpenAPI spec. Adds the `shared` field to `TestStepCreate`, which links a test case step to an existing shared step by hash.